### PR TITLE
fix: retrieve the correct bound properties

### DIFF
--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -758,8 +758,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         elif field_type in {"integer", "number"}:
             # For integer and float types we must check if there are imposed bounds
-            lower = properties.get("minimum") or properties.get("exclusiveMinimum")
-            upper = properties.get("maximum") or properties.get("exclusiveMaximum")
+            
+            lower = properties.get("minimum")
+            upper = properties.get("maximum")
+            
+            if lower is None:
+                lower = properties.get("exclusiveMinimum")
+            if upper is None:
+                upper = properties.get("exclusiveMaximum")
+            
 
             # If the dtype is an unsigned integer type, we must return a positive value
             if "dtype" in properties:


### PR DESCRIPTION
This closes: https://github.com/JakobGM/patito/issues/13

Doing `.get() or .get()` always returns None, so that's why the boundaries were not properly retrieved. 