### PR TITLE
Pydantic V2 Support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,20 @@ files = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.5.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "annotated_types-0.5.0-py3-none-any.whl", hash = "sha256:58da39888f92c276ad970249761ebea80ba544b77acddaa1a4d6cf78287d45fd"},
+    {file = "annotated_types-0.5.0.tar.gz", hash = "sha256:47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
+
+[[package]]
 name = "apeye"
 version = "1.4.0"
 description = "Handy tools for working with URLs and APIs."
@@ -1395,55 +1409,140 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.11"
-description = "Data validation and settings management using python type hints"
+version = "2.3.0"
+description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.10.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ff44c5e89315b15ff1f7fdaf9853770b810936d6b01a7bcecaa227d2f8fe444f"},
-    {file = "pydantic-1.10.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6c098d4ab5e2d5b3984d3cb2527e2d6099d3de85630c8934efcfdc348a9760e"},
-    {file = "pydantic-1.10.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16928fdc9cb273c6af00d9d5045434c39afba5f42325fb990add2c241402d151"},
-    {file = "pydantic-1.10.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0588788a9a85f3e5e9ebca14211a496409cb3deca5b6971ff37c556d581854e7"},
-    {file = "pydantic-1.10.11-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9baf78b31da2dc3d3f346ef18e58ec5f12f5aaa17ac517e2ffd026a92a87588"},
-    {file = "pydantic-1.10.11-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:373c0840f5c2b5b1ccadd9286782852b901055998136287828731868027a724f"},
-    {file = "pydantic-1.10.11-cp310-cp310-win_amd64.whl", hash = "sha256:c3339a46bbe6013ef7bdd2844679bfe500347ac5742cd4019a88312aa58a9847"},
-    {file = "pydantic-1.10.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08a6c32e1c3809fbc49debb96bf833164f3438b3696abf0fbeceb417d123e6eb"},
-    {file = "pydantic-1.10.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a451ccab49971af043ec4e0d207cbc8cbe53dbf148ef9f19599024076fe9c25b"},
-    {file = "pydantic-1.10.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b02d24f7b2b365fed586ed73582c20f353a4c50e4be9ba2c57ab96f8091ddae"},
-    {file = "pydantic-1.10.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f34739a89260dfa420aa3cbd069fbcc794b25bbe5c0a214f8fb29e363484b66"},
-    {file = "pydantic-1.10.11-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e297897eb4bebde985f72a46a7552a7556a3dd11e7f76acda0c1093e3dbcf216"},
-    {file = "pydantic-1.10.11-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d185819a7a059550ecb85d5134e7d40f2565f3dd94cfd870132c5f91a89cf58c"},
-    {file = "pydantic-1.10.11-cp311-cp311-win_amd64.whl", hash = "sha256:4400015f15c9b464c9db2d5d951b6a780102cfa5870f2c036d37c23b56f7fc1b"},
-    {file = "pydantic-1.10.11-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2417de68290434461a266271fc57274a138510dca19982336639484c73a07af6"},
-    {file = "pydantic-1.10.11-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:331c031ba1554b974c98679bd0780d89670d6fd6f53f5d70b10bdc9addee1713"},
-    {file = "pydantic-1.10.11-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8268a735a14c308923e8958363e3a3404f6834bb98c11f5ab43251a4e410170c"},
-    {file = "pydantic-1.10.11-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:44e51ba599c3ef227e168424e220cd3e544288c57829520dc90ea9cb190c3248"},
-    {file = "pydantic-1.10.11-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d7781f1d13b19700b7949c5a639c764a077cbbdd4322ed505b449d3ca8edcb36"},
-    {file = "pydantic-1.10.11-cp37-cp37m-win_amd64.whl", hash = "sha256:7522a7666157aa22b812ce14c827574ddccc94f361237ca6ea8bb0d5c38f1629"},
-    {file = "pydantic-1.10.11-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc64eab9b19cd794a380179ac0e6752335e9555d214cfcb755820333c0784cb3"},
-    {file = "pydantic-1.10.11-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8dc77064471780262b6a68fe67e013298d130414d5aaf9b562c33987dbd2cf4f"},
-    {file = "pydantic-1.10.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe429898f2c9dd209bd0632a606bddc06f8bce081bbd03d1c775a45886e2c1cb"},
-    {file = "pydantic-1.10.11-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:192c608ad002a748e4a0bed2ddbcd98f9b56df50a7c24d9a931a8c5dd053bd3d"},
-    {file = "pydantic-1.10.11-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ef55392ec4bb5721f4ded1096241e4b7151ba6d50a50a80a2526c854f42e6a2f"},
-    {file = "pydantic-1.10.11-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:41e0bb6efe86281623abbeeb0be64eab740c865388ee934cd3e6a358784aca6e"},
-    {file = "pydantic-1.10.11-cp38-cp38-win_amd64.whl", hash = "sha256:265a60da42f9f27e0b1014eab8acd3e53bd0bad5c5b4884e98a55f8f596b2c19"},
-    {file = "pydantic-1.10.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:469adf96c8e2c2bbfa655fc7735a2a82f4c543d9fee97bd113a7fb509bf5e622"},
-    {file = "pydantic-1.10.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e6cbfbd010b14c8a905a7b10f9fe090068d1744d46f9e0c021db28daeb8b6de1"},
-    {file = "pydantic-1.10.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abade85268cc92dff86d6effcd917893130f0ff516f3d637f50dadc22ae93999"},
-    {file = "pydantic-1.10.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9738b0f2e6c70f44ee0de53f2089d6002b10c33264abee07bdb5c7f03038303"},
-    {file = "pydantic-1.10.11-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:787cf23e5a0cde753f2eabac1b2e73ae3844eb873fd1f5bdbff3048d8dbb7604"},
-    {file = "pydantic-1.10.11-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:174899023337b9fc685ac8adaa7b047050616136ccd30e9070627c1aaab53a13"},
-    {file = "pydantic-1.10.11-cp39-cp39-win_amd64.whl", hash = "sha256:1954f8778489a04b245a1e7b8b22a9d3ea8ef49337285693cf6959e4b757535e"},
-    {file = "pydantic-1.10.11-py3-none-any.whl", hash = "sha256:008c5e266c8aada206d0627a011504e14268a62091450210eda7c07fabe6963e"},
-    {file = "pydantic-1.10.11.tar.gz", hash = "sha256:f66d479cf7eb331372c470614be6511eae96f1f120344c25f3f9bb59fb1b5528"},
+    {file = "pydantic-2.3.0-py3-none-any.whl", hash = "sha256:45b5e446c6dfaad9444819a293b921a40e1db1aa61ea08aede0522529ce90e81"},
+    {file = "pydantic-2.3.0.tar.gz", hash = "sha256:1607cc106602284cd4a00882986570472f193fde9cb1259bceeaedb26aa79a6d"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.2.0"
+annotated-types = ">=0.4.0"
+pydantic-core = "2.6.3"
+typing-extensions = ">=4.6.1"
 
 [package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
+email = ["email-validator (>=2.0.0)"]
+
+[[package]]
+name = "pydantic-core"
+version = "2.6.3"
+description = ""
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pydantic_core-2.6.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:1a0ddaa723c48af27d19f27f1c73bdc615c73686d763388c8683fe34ae777bad"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5cfde4fab34dd1e3a3f7f3db38182ab6c95e4ea91cf322242ee0be5c2f7e3d2f"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5493a7027bfc6b108e17c3383959485087d5942e87eb62bbac69829eae9bc1f7"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84e87c16f582f5c753b7f39a71bd6647255512191be2d2dbf49458c4ef024588"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:522a9c4a4d1924facce7270c84b5134c5cabcb01513213662a2e89cf28c1d309"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaafc776e5edc72b3cad1ccedb5fd869cc5c9a591f1213aa9eba31a781be9ac1"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a750a83b2728299ca12e003d73d1264ad0440f60f4fc9cee54acc489249b728"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e8b374ef41ad5c461efb7a140ce4730661aadf85958b5c6a3e9cf4e040ff4bb"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b594b64e8568cf09ee5c9501ede37066b9fc41d83d58f55b9952e32141256acd"},
+    {file = "pydantic_core-2.6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2a20c533cb80466c1d42a43a4521669ccad7cf2967830ac62c2c2f9cece63e7e"},
+    {file = "pydantic_core-2.6.3-cp310-none-win32.whl", hash = "sha256:04fe5c0a43dec39aedba0ec9579001061d4653a9b53a1366b113aca4a3c05ca7"},
+    {file = "pydantic_core-2.6.3-cp310-none-win_amd64.whl", hash = "sha256:6bf7d610ac8f0065a286002a23bcce241ea8248c71988bda538edcc90e0c39ad"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:6bcc1ad776fffe25ea5c187a028991c031a00ff92d012ca1cc4714087e575973"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df14f6332834444b4a37685810216cc8fe1fe91f447332cd56294c984ecbff1c"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0b7486d85293f7f0bbc39b34e1d8aa26210b450bbd3d245ec3d732864009819"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a892b5b1871b301ce20d40b037ffbe33d1407a39639c2b05356acfef5536d26a"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:883daa467865e5766931e07eb20f3e8152324f0adf52658f4d302242c12e2c32"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4eb77df2964b64ba190eee00b2312a1fd7a862af8918ec70fc2d6308f76ac64"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ce8c84051fa292a5dc54018a40e2a1926fd17980a9422c973e3ebea017aa8da"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:22134a4453bd59b7d1e895c455fe277af9d9d9fbbcb9dc3f4a97b8693e7e2c9b"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:02e1c385095efbd997311d85c6021d32369675c09bcbfff3b69d84e59dc103f6"},
+    {file = "pydantic_core-2.6.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d79f1f2f7ebdb9b741296b69049ff44aedd95976bfee38eb4848820628a99b50"},
+    {file = "pydantic_core-2.6.3-cp311-none-win32.whl", hash = "sha256:430ddd965ffd068dd70ef4e4d74f2c489c3a313adc28e829dd7262cc0d2dd1e8"},
+    {file = "pydantic_core-2.6.3-cp311-none-win_amd64.whl", hash = "sha256:84f8bb34fe76c68c9d96b77c60cef093f5e660ef8e43a6cbfcd991017d375950"},
+    {file = "pydantic_core-2.6.3-cp311-none-win_arm64.whl", hash = "sha256:5a2a3c9ef904dcdadb550eedf3291ec3f229431b0084666e2c2aa8ff99a103a2"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:8421cf496e746cf8d6b677502ed9a0d1e4e956586cd8b221e1312e0841c002d5"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bb128c30cf1df0ab78166ded1ecf876620fb9aac84d2413e8ea1594b588c735d"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37a822f630712817b6ecc09ccc378192ef5ff12e2c9bae97eb5968a6cdf3b862"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:240a015102a0c0cc8114f1cba6444499a8a4d0333e178bc504a5c2196defd456"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f90e5e3afb11268628c89f378f7a1ea3f2fe502a28af4192e30a6cdea1e7d5e"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:340e96c08de1069f3d022a85c2a8c63529fd88709468373b418f4cf2c949fb0e"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1480fa4682e8202b560dcdc9eeec1005f62a15742b813c88cdc01d44e85308e5"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f14546403c2a1d11a130b537dda28f07eb6c1805a43dae4617448074fd49c282"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a87c54e72aa2ef30189dc74427421e074ab4561cf2bf314589f6af5b37f45e6d"},
+    {file = "pydantic_core-2.6.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f93255b3e4d64785554e544c1c76cd32f4a354fa79e2eeca5d16ac2e7fdd57aa"},
+    {file = "pydantic_core-2.6.3-cp312-none-win32.whl", hash = "sha256:f70dc00a91311a1aea124e5f64569ea44c011b58433981313202c46bccbec0e1"},
+    {file = "pydantic_core-2.6.3-cp312-none-win_amd64.whl", hash = "sha256:23470a23614c701b37252618e7851e595060a96a23016f9a084f3f92f5ed5881"},
+    {file = "pydantic_core-2.6.3-cp312-none-win_arm64.whl", hash = "sha256:1ac1750df1b4339b543531ce793b8fd5c16660a95d13aecaab26b44ce11775e9"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:a53e3195f134bde03620d87a7e2b2f2046e0e5a8195e66d0f244d6d5b2f6d31b"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:f2969e8f72c6236c51f91fbb79c33821d12a811e2a94b7aa59c65f8dbdfad34a"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:672174480a85386dd2e681cadd7d951471ad0bb028ed744c895f11f9d51b9ebe"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:002d0ea50e17ed982c2d65b480bd975fc41086a5a2f9c924ef8fc54419d1dea3"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ccc13afee44b9006a73d2046068d4df96dc5b333bf3509d9a06d1b42db6d8bf"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:439a0de139556745ae53f9cc9668c6c2053444af940d3ef3ecad95b079bc9987"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d63b7545d489422d417a0cae6f9898618669608750fc5e62156957e609e728a5"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b44c42edc07a50a081672e25dfe6022554b47f91e793066a7b601ca290f71e42"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1c721bfc575d57305dd922e6a40a8fe3f762905851d694245807a351ad255c58"},
+    {file = "pydantic_core-2.6.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5e4a2cf8c4543f37f5dc881de6c190de08096c53986381daebb56a355be5dfe6"},
+    {file = "pydantic_core-2.6.3-cp37-none-win32.whl", hash = "sha256:d9b4916b21931b08096efed090327f8fe78e09ae8f5ad44e07f5c72a7eedb51b"},
+    {file = "pydantic_core-2.6.3-cp37-none-win_amd64.whl", hash = "sha256:a8acc9dedd304da161eb071cc7ff1326aa5b66aadec9622b2574ad3ffe225525"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:5e9c068f36b9f396399d43bfb6defd4cc99c36215f6ff33ac8b9c14ba15bdf6b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e61eae9b31799c32c5f9b7be906be3380e699e74b2db26c227c50a5fc7988698"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d85463560c67fc65cd86153a4975d0b720b6d7725cf7ee0b2d291288433fc21b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9616567800bdc83ce136e5847d41008a1d602213d024207b0ff6cab6753fe645"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e9b65a55bbabda7fccd3500192a79f6e474d8d36e78d1685496aad5f9dbd92c"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f468d520f47807d1eb5d27648393519655eadc578d5dd862d06873cce04c4d1b"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9680dd23055dd874173a3a63a44e7f5a13885a4cfd7e84814be71be24fba83db"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a718d56c4d55efcfc63f680f207c9f19c8376e5a8a67773535e6f7e80e93170"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8ecbac050856eb6c3046dea655b39216597e373aa8e50e134c0e202f9c47efec"},
+    {file = "pydantic_core-2.6.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:788be9844a6e5c4612b74512a76b2153f1877cd845410d756841f6c3420230eb"},
+    {file = "pydantic_core-2.6.3-cp38-none-win32.whl", hash = "sha256:07a1aec07333bf5adebd8264047d3dc518563d92aca6f2f5b36f505132399efc"},
+    {file = "pydantic_core-2.6.3-cp38-none-win_amd64.whl", hash = "sha256:621afe25cc2b3c4ba05fff53525156d5100eb35c6e5a7cf31d66cc9e1963e378"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:813aab5bfb19c98ae370952b6f7190f1e28e565909bfc219a0909db168783465"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:50555ba3cb58f9861b7a48c493636b996a617db1a72c18da4d7f16d7b1b9952b"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19e20f8baedd7d987bd3f8005c146e6bcbda7cdeefc36fad50c66adb2dd2da48"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b0a5d7edb76c1c57b95df719af703e796fc8e796447a1da939f97bfa8a918d60"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f06e21ad0b504658a3a9edd3d8530e8cea5723f6ea5d280e8db8efc625b47e49"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea053cefa008fda40f92aab937fb9f183cf8752e41dbc7bc68917884454c6362"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:171a4718860790f66d6c2eda1d95dd1edf64f864d2e9f9115840840cf5b5713f"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ed7ceca6aba5331ece96c0e328cd52f0dcf942b8895a1ed2642de50800b79d3"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:acafc4368b289a9f291e204d2c4c75908557d4f36bd3ae937914d4529bf62a76"},
+    {file = "pydantic_core-2.6.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1aa712ba150d5105814e53cb141412217146fedc22621e9acff9236d77d2a5ef"},
+    {file = "pydantic_core-2.6.3-cp39-none-win32.whl", hash = "sha256:44b4f937b992394a2e81a5c5ce716f3dcc1237281e81b80c748b2da6dd5cf29a"},
+    {file = "pydantic_core-2.6.3-cp39-none-win_amd64.whl", hash = "sha256:9b33bf9658cb29ac1a517c11e865112316d09687d767d7a0e4a63d5c640d1b17"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:d7050899026e708fb185e174c63ebc2c4ee7a0c17b0a96ebc50e1f76a231c057"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:99faba727727b2e59129c59542284efebbddade4f0ae6a29c8b8d3e1f437beb7"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fa159b902d22b283b680ef52b532b29554ea2a7fc39bf354064751369e9dbd7"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:046af9cfb5384f3684eeb3f58a48698ddab8dd870b4b3f67f825353a14441418"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:930bfe73e665ebce3f0da2c6d64455098aaa67e1a00323c74dc752627879fc67"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:85cc4d105747d2aa3c5cf3e37dac50141bff779545ba59a095f4a96b0a460e70"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b25afe9d5c4f60dcbbe2b277a79be114e2e65a16598db8abee2a2dcde24f162b"},
+    {file = "pydantic_core-2.6.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e49ce7dc9f925e1fb010fc3d555250139df61fa6e5a0a95ce356329602c11ea9"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:2dd50d6a1aef0426a1d0199190c6c43ec89812b1f409e7fe44cb0fbf6dfa733c"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6595b0d8c8711e8e1dc389d52648b923b809f68ac1c6f0baa525c6440aa0daa"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ef724a059396751aef71e847178d66ad7fc3fc969a1a40c29f5aac1aa5f8784"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3c8945a105f1589ce8a693753b908815e0748f6279959a4530f6742e1994dcb6"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c8c6660089a25d45333cb9db56bb9e347241a6d7509838dbbd1931d0e19dbc7f"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:692b4ff5c4e828a38716cfa92667661a39886e71136c97b7dac26edef18767f7"},
+    {file = "pydantic_core-2.6.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:f1a5d8f18877474c80b7711d870db0eeef9442691fcdb00adabfc97e183ee0b0"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3796a6152c545339d3b1652183e786df648ecdf7c4f9347e1d30e6750907f5bb"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:b962700962f6e7a6bd77e5f37320cabac24b4c0f76afeac05e9f93cf0c620014"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56ea80269077003eaa59723bac1d8bacd2cd15ae30456f2890811efc1e3d4413"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c0ebbebae71ed1e385f7dfd9b74c1cff09fed24a6df43d326dd7f12339ec34"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:252851b38bad3bfda47b104ffd077d4f9604a10cb06fe09d020016a25107bf98"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:6656a0ae383d8cd7cc94e91de4e526407b3726049ce8d7939049cbfa426518c8"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:d9140ded382a5b04a1c030b593ed9bf3088243a0a8b7fa9f071a5736498c5483"},
+    {file = "pydantic_core-2.6.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d38bbcef58220f9c81e42c255ef0bf99735d8f11edef69ab0b499da77105158a"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:c9d469204abcca28926cbc28ce98f28e50e488767b084fb3fbdf21af11d3de26"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:48c1ed8b02ffea4d5c9c220eda27af02b8149fe58526359b3c07eb391cb353a2"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b2b1bfed698fa410ab81982f681f5b1996d3d994ae8073286515ac4d165c2e7"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf9d42a71a4d7a7c1f14f629e5c30eac451a6fc81827d2beefd57d014c006c4a"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4292ca56751aebbe63a84bbfc3b5717abb09b14d4b4442cc43fd7c49a1529efd"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:7dc2ce039c7290b4ef64334ec7e6ca6494de6eecc81e21cb4f73b9b39991408c"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:615a31b1629e12445c0e9fc8339b41aaa6cc60bd53bf802d5fe3d2c0cda2ae8d"},
+    {file = "pydantic_core-2.6.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1fa1f6312fb84e8c281f32b39affe81984ccd484da6e9d65b3d18c202c666149"},
+    {file = "pydantic_core-2.6.3.tar.gz", hash = "sha256:1508f37ba9e3ddc0189e6ff4e2228bd2d3c3a4641cbe8c07177162f76ed696c7"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pyflakes"
@@ -2290,4 +2389,4 @@ pandas = ["pandas"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "65cee0051a8479939b886004fcc59ec87c7a7a6d396a4c55890fe63457557eeb"
+content-hash = "e35a4ac293d5b833ab2216d48d0814edf3206fcdf26c6adc9824fc885aea40df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["validation", "dataframe"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pydantic = "^1.7.0"
+pydantic = ">=2.0.0"
 polars = ">=0.18.7"
 # Required for typing.Literal in python3.7
 typing-extensions = "*"
@@ -110,6 +110,7 @@ warn_no_return = true
 warn_unreachable = true
 allow_redefinition = true
 show_error_codes = true
+enable_incomplete_feature = ["Unpack"]
 exclude = [
   "noxfile.py",
 ]

--- a/src/patito/__init__.py
+++ b/src/patito/__init__.py
@@ -28,10 +28,15 @@ __all__ = [
 try:
     from patito import duckdb
 
-    _DUCKDB_AVAILABLE = True
     __all__ += ["duckdb"]
 except ImportError:  # pragma: no cover
     pass
+
+try:
+    import duckdb as _duckdb
+except ImportError:  # pragma: no cover
+    _DUCKDB_AVAILABLE = False
+
 
 try:
     from patito.database import Database

--- a/src/patito/exceptions.py
+++ b/src/patito/exceptions.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class ValidationError(ValueError):
     """Exception raised when dataframe does not match schema."""
 
-    def __init__(self, errors: Sequence["ErrorWrapper"], model: Model) -> None:
+    def __init__(self, errors: Sequence["ErrorWrapper"], model: type[Model]) -> None:
         self.raw_errors = errors
         self.model = model
 

--- a/src/patito/exceptions.py
+++ b/src/patito/exceptions.py
@@ -1,43 +1,84 @@
 """Module containing all custom exceptions raised by patito."""
+from __future__ import annotations
 
-import pydantic
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+import pydantic.v1 as pydantic
+
+if TYPE_CHECKING:
+    from patito.pydantic import Model
 
 
-class ValidationError(pydantic.ValidationError):
+class ValidationError(ValueError):
     """Exception raised when dataframe does not match schema."""
 
+    def __init__(self, errors: Sequence["ErrorWrapper"], model: Model) -> None:
+        self.raw_errors = errors
+        self.model = model
 
-class ErrorWrapper(pydantic.error_wrappers.ErrorWrapper):
+    def errors(self) -> Sequence[pydantic.ValidationError]:
+        """Return a list of pydantic validation errors."""
+        return [e.as_dict() for e in self.raw_errors]
+
+
+class ErrorWrapper:
     """Wrapper for specific column validation error."""
+
+    def __init__(self, exc: Exception, loc: str) -> None:
+        self.exc = exc
+        self._loc = loc
+
+    def as_dict(self) -> dict:
+        return {
+            "loc": (self._loc,),
+            "msg": str(self.exc),
+            "type": self.exc._type,
+        }
 
 
 class WrongColumnsError(TypeError):
     """Validation exception for column name mismatches."""
 
+    _type = "type_error.wrongcolumns"
+
 
 class MissingColumnsError(WrongColumnsError):
     """Exception for when a dataframe is missing one or more columns."""
+
+    _type = "type_error.missingcolumns"
 
 
 class SuperflousColumnsError(WrongColumnsError):
     """Exception for when a dataframe has one ore more non-specified columns."""
 
+    _type = "type_error.superflouscolumns"
+
 
 class MissingValuesError(ValueError):
     """Exception for when a dataframe has non-nullable columns with nulls."""
+
+    _type = "value_error.missingvalues"
 
 
 class ColumnDTypeError(TypeError):
     """Exception for when a dataframe has one or more columns with wrong dtypes."""
 
+    _type = "type_error.columndtype"
+
 
 class RowValueError(ValueError):
     """Exception for when a dataframe has a row with a impermissible value."""
+
+    _type = "value_error.rowvalue"
 
 
 class RowDoesNotExist(RuntimeError):
     """Exception for when a single row was expected, but none were returned."""
 
+    _type = "value_error.rowdoesnotexist"
+
 
 class MultipleRowsReturned(RuntimeError):
     """Exception for when a single row was expected, but several were returned."""
+
+    _type = "value_error.multiplerowsreturned"

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -60,7 +60,7 @@ class LazyFrame(pl.LazyFrame, Generic[ModelType]):
             return cls
 
         new_class = type(
-            f"{model.schema()['title']}LazyFrame",
+            f"{model.model_json_schema()['title']}LazyFrame",
             (cls,),
             {"model": model},
         )
@@ -150,7 +150,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
                 "hard-coded" to the given model.
         """
         new_class = type(
-            f"{model.schema()['title']}DataFrame",
+            f"{model.model_json_schema()['title']}DataFrame",
             (cls,),
             {"model": model},
         )

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -220,7 +220,7 @@ class ModelMetaclass(PydanticModelMetaclass):
 
     @staticmethod
     def _valid_dtypes(  # noqa: C901
-        props: Dict,
+        props: dict[str, Any],
     ) -> Optional[List[pl.PolarsDataType]]:
         """
         Map schema property to list of valid polars data types.
@@ -232,8 +232,12 @@ class ModelMetaclass(PydanticModelMetaclass):
             List of valid dtypes. None if no mapping exists.
         """
         if "anyOf" in props:
+            nested_valid_dtypes: list[list[pl.PolarsDataType]] = []
+            for valid_dtypes in (Model._valid_dtypes(p) for p in props["anyOf"]):
+                if valid_dtypes is not None:
+                    nested_valid_dtypes.append(valid_dtypes)
             return list(
-                itertools.chain(*(Model._valid_dtypes(p) for p in props["anyOf"]))
+                itertools.chain(*nested_valid_dtypes)
             )
         if "dtype" in props:
             return [

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -1151,6 +1151,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         ):
             for field_name, field in model.model_fields.items():
                 field_annotation = field.annotation
+                # Fix type error that field_annotation has type `type | None`,
+                # we want field_annotation as either `type` or `type | Type[None]`,
+                # where the latter means nullable
+                assert field_annotation is not None, "Column type cannot be null!"
+
                 if how in nullable_methods and type(None) not in get_args(
                     field_annotation
                 ):

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import itertools
-import json
 from collections.abc import Iterable
 from datetime import date, datetime
 from typing import (
@@ -232,7 +231,6 @@ class ModelMetaclass(PydanticModelMetaclass):
         Returns:
             List of valid dtypes. None if no mapping exists.
         """
-        print("Hi", props)
         if "anyOf" in props:
             return list(
                 itertools.chain(*(Model._valid_dtypes(p) for p in props["anyOf"]))
@@ -717,7 +715,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if validate:
             return cls(**dataframe.to_dicts()[0])
         else:
-            return cls.construct(**dataframe.to_dicts()[0])
+            return cls.model_construct(**dataframe.to_dicts()[0])
 
     @classmethod
     def validate(
@@ -1148,10 +1146,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             (other, {"left", "outer", "asof"}),
         ):
             for field_name, field in model.model_fields.items():
-                print(type(field))
-                print(dir(field))
                 field_annotation = field.annotation
-                field_default = field.default
                 if how in nullable_methods and type(None) not in get_args(
                     field_annotation
                 ):
@@ -1452,7 +1447,6 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 # We have been given a (field_type, field_default) tuple defining the
                 # new field directly.
                 new_fields[new_field_name] = field_definition
-        print(new_fields)
         return create_model(  # type: ignore
             __model_name=model_name,
             __base__=Model,

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import itertools
+import json
 from collections.abc import Iterable
 from datetime import date, datetime
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Dict,
     List,
@@ -20,8 +22,19 @@ from typing import (
 
 import polars as pl
 from polars.datatypes import PolarsDataType
-from pydantic import BaseConfig, BaseModel, Field, create_model  # noqa: F401
-from pydantic.main import ModelMetaclass as PydanticModelMetaclass
+from pydantic import BaseModel, create_model  # noqa: F401
+from pydantic import Field as PydanticField
+from pydantic._internal._model_construction import (
+    ModelMetaclass as PydanticModelMetaclass,
+)
+from pydantic.fields import (
+    AliasChoices,
+    AliasPath,
+    PydanticUndefined,
+    Unpack,
+    _EmptyKwargs,  # pyright: ignore[reportPrivateUsage]
+    _Unset,  # pyright: ignore[reportPrivateUsage]
+)
 from typing_extensions import Literal, get_args
 
 from patito.polars import DataFrame, LazyFrame
@@ -32,7 +45,7 @@ try:
 
     _PANDAS_AVAILABLE = True
 except ImportError:
-    _PANDAS_AVAILABLE = False
+    _PANDAS_AVAILABLE = False  # pyright: ignore[reportConstantRedefinition]
 
 if TYPE_CHECKING:
     import patito.polars
@@ -58,6 +71,17 @@ PYDANTIC_TO_POLARS_TYPES = {
     "boolean": pl.Boolean,
 }
 
+PATITO_INTEGER_TYPES = [
+    pl.Int64,
+    pl.Int32,
+    pl.Int16,
+    pl.Int8,
+    pl.UInt64,
+    pl.UInt32,
+    pl.UInt16,
+    pl.UInt8,
+]
+
 
 class ModelMetaclass(PydanticModelMetaclass):
     """
@@ -66,7 +90,7 @@ class ModelMetaclass(PydanticModelMetaclass):
     Responsible for setting any relevant model-dependent class properties.
     """
 
-    def __init__(cls, name: str, bases: tuple, clsdict: dict) -> None:
+    def __init__(cls, name: str, bases: tuple, clsdict: dict, **kwargs) -> None:
         """
         Construct new patito model.
 
@@ -75,7 +99,7 @@ class ModelMetaclass(PydanticModelMetaclass):
             bases: Tuple of superclasses.
             clsdict: Dictionary containing class properties.
         """
-        super().__init__(name, bases, clsdict)
+        super().__init__(name, bases, clsdict, **kwargs)
         # Add a custom subclass of patito.DataFrame to the model class,
         # where .set_model() has been implicitly set.
         cls.DataFrame = DataFrame._construct_dataframe_model_class(
@@ -107,7 +131,7 @@ class ModelMetaclass(PydanticModelMetaclass):
             >>> Product.columns
             ['name', 'price']
         """
-        return list(cls.schema()["properties"].keys())
+        return list(cls.model_json_schema()["properties"].keys())
 
     @property
     def dtypes(  # type: ignore
@@ -172,7 +196,12 @@ class ModelMetaclass(PydanticModelMetaclass):
         for column, props in cls._schema_properties().items():
             column_dtypes: List[Union[PolarsDataType, pl.List]]
             if props.get("type") == "array":
-                array_props = props["items"]
+                if "items" in props:
+                    array_props = props["items"]
+                else:
+                    array_props = next(
+                        t["items"] for t in props["anyOf"] if t["type"] != "null"
+                    )
                 item_dtypes = cls._valid_dtypes(props=array_props)
                 if item_dtypes is None:
                     raise NotImplementedError(
@@ -203,6 +232,11 @@ class ModelMetaclass(PydanticModelMetaclass):
         Returns:
             List of valid dtypes. None if no mapping exists.
         """
+        print("Hi", props)
+        if "anyOf" in props:
+            return list(
+                itertools.chain(*(Model._valid_dtypes(p) for p in props["anyOf"]))
+            )
         if "dtype" in props:
             return [
                 props["dtype"],
@@ -210,7 +244,24 @@ class ModelMetaclass(PydanticModelMetaclass):
         elif "enum" in props and props["type"] == "string":
             return [pl.Categorical, pl.Utf8]
         elif "type" not in props:
-            return None
+            if "const" not in props:
+                return None
+            return {
+                int: [
+                    pl.Int64,
+                    pl.Int32,
+                    pl.Int16,
+                    pl.Int8,
+                    pl.UInt64,
+                    pl.UInt32,
+                    pl.UInt16,
+                    pl.UInt8,
+                ],
+                str: [pl.Utf8],
+                float: [pl.Float64, pl.Float32],
+                bool: [pl.Boolean],
+                # TODO: Fix remaining types
+            }[type(props["const"])]
         elif props["type"] == "integer":
             return [
                 pl.Int64,
@@ -223,16 +274,15 @@ class ModelMetaclass(PydanticModelMetaclass):
                 pl.UInt8,
             ]
         elif props["type"] == "number":
-            if props.get("format") == "time-delta":
-                return [pl.Duration]
-            else:
-                return [pl.Float64, pl.Float32]
+            return [pl.Float64, pl.Float32]
         elif props["type"] == "boolean":
             return [pl.Boolean]
         elif props["type"] == "string":
             string_format = props.get("format")
             if string_format is None:
                 return [pl.Utf8]
+            elif string_format == "duration":
+                return [pl.Duration]
             elif string_format == "date":
                 return [pl.Date]
             # TODO: Find out why this branch is not being hit
@@ -460,7 +510,7 @@ class ModelMetaclass(PydanticModelMetaclass):
             >>> sorted(MyModel.non_nullable_columns)
             ['another_non_nullable_field', 'non_nullable_field']
         """
-        return set(cls.schema().get("required", {}))
+        return set(cls.columns) - cls.nullable_columns
 
     @property
     def nullable_columns(  # type: ignore
@@ -484,7 +534,17 @@ class ModelMetaclass(PydanticModelMetaclass):
             >>> sorted(MyModel.nullable_columns)
             ['inferred_nullable_field', 'nullable_field']
         """
-        return set(cls.columns) - cls.non_nullable_columns
+        return set(
+            field_name
+            for field_name, field_info in cls._schema_properties().items()
+            if field_info["nullable"]
+        )
+
+    @property
+    def required_columns(  # type: ignore
+        cls: Type[ModelType],  # pyright: ignore
+    ) -> set[str]:
+        return set(cls.model_json_schema()["required"])
 
     @property
     def unique_columns(  # type: ignore
@@ -741,16 +801,16 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         """
         field_data = cls._schema_properties()
         properties = field_data[field]
-        field_type = properties["type"]
         if "const" in properties:
             # The default value is the only valid value, provided as const
             return properties["const"]
 
-        elif "default" in properties:
+        field_type = properties["type"]
+        if "default" in properties:
             # A default value has been specified in the model field definition
             return properties["default"]
 
-        elif not properties["required"]:
+        elif properties["nullable"]:
             return None
 
         elif "enum" in properties:
@@ -932,7 +992,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         dummies = []
         for values in zip(*kwargs.values()):
             dummies.append(cls.example(**dict(zip(kwargs.keys(), values))))
-        return pd.DataFrame([dummy.dict() for dummy in dummies])
+        return pd.DataFrame([dummy.model_dump() for dummy in dummies])
 
     @classmethod
     def examples(
@@ -1087,18 +1147,17 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             (cls, {"outer"}),
             (other, {"left", "outer", "asof"}),
         ):
-            for field_name, field in model.__fields__.items():
-                field_type = field.type_
+            for field_name, field in model.model_fields.items():
+                print(type(field))
+                print(dir(field))
+                field_annotation = field.annotation
                 field_default = field.default
-                if how in nullable_methods and type(None) not in get_args(field.type_):
+                if how in nullable_methods and type(None) not in get_args(
+                    field_annotation
+                ):
                     # This originally non-nullable field has become nullable
-                    field_type = Optional[field_type]
-                elif field.required and field_default is None:
-                    # We need to replace Pydantic's None default value with ... in order
-                    # to make it clear that the field is still non-nullable and
-                    # required.
-                    field_default = ...
-                kwargs[field_name] = (field_type, field_default)
+                    field_annotation = Optional[field_annotation]
+                kwargs[field_name] = (field_annotation, field)
 
         return create_model(
             f"{cls.__name__}{how.capitalize()}Join{other.__name__}",
@@ -1332,32 +1391,30 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             TypeError: if a field is annotated with an enum where the values are of
                 different types.
         """
-        schema = cls.schema(ref_template="{model}")
-        required = schema.get("required", set())
-        fields = {}
+        schema = cls.model_json_schema(ref_template="{model}")
+        required = set(schema.get("required", set()))
+        fields: Dict[str, Dict[str, Any]] = {}
         for field_name, field_info in schema["properties"].items():
             if "$ref" in field_info:
-                definition = schema["definitions"][field_info["$ref"]]
-                if "enum" in definition and "type" not in definition:
-                    enum_types = set(type(value) for value in definition["enum"])
-                    if len(enum_types) > 1:
-                        raise TypeError(
-                            "All enumerated values of enums used to annotate "
-                            "Patito model fields must have the same type. "
-                            "Encountered types: "
-                            f"{sorted(map(lambda t: t.__name__, enum_types))}."
-                        )
-                    enum_type = enum_types.pop()
-                    # TODO: Support time-delta, date, and date-time.
-                    definition["type"] = {
-                        str: "string",
-                        int: "integer",
-                        float: "number",
-                        bool: "boolean",
-                        type(None): "null",
-                    }[enum_type]
-                fields[field_name] = definition
+                enum_definition = schema["$defs"][field_info["$ref"]]
+                enum_definition["nullable"] = "anyOf" in field_info and any(
+                    info.get("type") == "null" for info in field_info["anyOf"]
+                )
+                fields[field_name] = enum_definition
             else:
+                if "type" not in field_info and "anyOf" in field_info:
+                    nullable = any(
+                        info.get("type") == "null" for info in field_info["anyOf"]
+                    )
+                else:
+                    nullable = False
+
+                if "type" not in field_info and "anyOf" in field_info:
+                    field_info["type"] = next(
+                        (p["type"] for p in field_info["anyOf"] if p["type"] != "null"),
+                        field_info["anyOf"][0],
+                    )
+                field_info["nullable"] = nullable
                 fields[field_name] = field_info
             fields[field_name]["required"] = field_name in required
 
@@ -1388,27 +1445,61 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             if isinstance(field_definition, str):
                 # A single string, interpreted as the name of a field on the existing
                 # model.
-                old_field = cls.__fields__[field_definition]
-                field_type = old_field.type_
-                field_default = old_field.default
-                if old_field.required and field_default is None:
-                    # The default None value needs to be replaced with ... in order to
-                    # make the field required in the new model.
-                    field_default = ...
-                new_fields[new_field_name] = (field_type, field_default)
+                field_info = cls.model_fields[field_definition]
+                field_annotation = field_info.annotation
+                new_fields[new_field_name] = (field_annotation, field_info)
             else:
                 # We have been given a (field_type, field_default) tuple defining the
                 # new field directly.
                 new_fields[new_field_name] = field_definition
+        print(new_fields)
         return create_model(  # type: ignore
             __model_name=model_name,
-            __validators__={"__validators__": cls.__validators__},
             __base__=Model,
             **new_fields,
         )
 
 
-class FieldDoc:
+def Field(  # noqa: C901
+    default: Any = PydanticUndefined,
+    *,
+    default_factory: Callable[[], Any] | None = _Unset,
+    alias: str | None = _Unset,
+    alias_priority: int | None = _Unset,
+    validation_alias: str | AliasPath | AliasChoices | None = _Unset,
+    serialization_alias: str | None = _Unset,
+    title: str | None = _Unset,
+    description: str | None = _Unset,
+    examples: list[Any] | None = _Unset,
+    exclude: bool | None = _Unset,
+    discriminator: str | None = _Unset,
+    json_schema_extra: (
+        dict[str, Any] | Callable[[dict[str, Any]], None] | None
+    ) = _Unset,
+    frozen: bool | None = _Unset,
+    validate_default: bool | None = _Unset,
+    repr: bool = _Unset,
+    init_var: bool | None = _Unset,
+    kw_only: bool | None = _Unset,
+    pattern: str | None = _Unset,
+    strict: bool | None = _Unset,
+    gt: float | None = _Unset,
+    ge: float | None = _Unset,
+    lt: float | None = _Unset,
+    le: float | None = _Unset,
+    multiple_of: float | None = _Unset,
+    allow_inf_nan: bool | None = _Unset,
+    max_digits: int | None = _Unset,
+    decimal_places: int | None = _Unset,
+    min_length: int | None = _Unset,
+    max_length: int | None = _Unset,
+    # Patito-specific arguments that extends upon Pydantic
+    constraints: Union[pl.Expr, List[pl.Expr]] | None = None,
+    derived_from: str | pl.Expr | None = None,
+    dtype: pl.DataType | None = None,
+    unique: bool = False,
+    **extra: Unpack[_EmptyKwargs],
+) -> Any:
     """
     Annotate model field with additional type and validation information.
 
@@ -1431,8 +1522,6 @@ class FieldDoc:
         lt: All values must be less than ``lt``.
         le: All values must be less than or equal to ``lt``.
         multiple_of: All values must be multiples of the given value.
-        const (bool): If set to ``True`` `all` values must be equal to the provided
-            default value, the first argument provided to the ``Field`` constructor.
         regex (str): UTF-8 string column must match regex pattern for all row values.
         min_length (int): Minimum length of all string values in a UTF-8 column.
         max_length (int): Maximum length of all string values in a UTF-8 column.
@@ -1477,6 +1566,53 @@ class FieldDoc:
         brand_color
           2 rows with out of bound values. (type=value_error.rowvalue)
     """
+    if callable(json_schema_extra):
+        raise NotImplementedError(
+            "Callable json_schema_extra has not yet been implemented. "
+            "Please create an issue on the Patito repository if you need this feature."
+        )
+    if json_schema_extra == _Unset:
+        json_schema_extra = {}
+    else:
+        json_schema_extra = json_schema_extra or {}
 
+    json_schema_extra["unique"] = unique
+    if constraints is not None:
+        json_schema_extra["constraints"] = constraints
+    if dtype is not None:
+        json_schema_extra["dtype"] = dtype
+    if derived_from is not None:
+        json_schema_extra["derived_from"] = derived_from
 
-Field.__doc__ = FieldDoc.__doc__
+    return PydanticField(
+        default=default,
+        default_factory=default_factory,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        examples=examples,
+        exclude=exclude,
+        discriminator=discriminator,
+        json_schema_extra=json_schema_extra,
+        frozen=frozen,
+        validate_default=validate_default,
+        repr=repr,
+        init_var=init_var,
+        kw_only=kw_only,
+        pattern=pattern,
+        strict=strict,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        min_length=min_length,
+        max_length=max_length,
+        **extra,
+    )

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -135,7 +135,7 @@ class ModelMetaclass(PydanticModelMetaclass):
     @property
     def dtypes(  # type: ignore
         cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, Type[pl.DataType]]:
+    ) -> dict[str, pl.PolarsDataType]:
         """
         Return the polars dtypes of the dataframe.
 
@@ -162,7 +162,7 @@ class ModelMetaclass(PydanticModelMetaclass):
     @property
     def valid_dtypes(  # type: ignore
         cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, List[Union[pl.PolarsDataType, pl.List]]]:
+    ) -> dict[str, List[pl.PolarsDataType]]:
         """
         Return a list of polars dtypes which Patito considers valid for each field.
 
@@ -1490,7 +1490,7 @@ def Field(  # noqa: C901
     # Patito-specific arguments that extends upon Pydantic
     constraints: Union[pl.Expr, List[pl.Expr]] | None = None,
     derived_from: str | pl.Expr | None = None,
-    dtype: pl.DataType | None = None,
+    dtype: pl.PolarsDataType | None = None,
     unique: bool = False,
     **extra: Unpack[_EmptyKwargs],
 ) -> Any:

--- a/tests/test_duckdb/test_relation.py
+++ b/tests/test_duckdb/test_relation.py
@@ -4,11 +4,10 @@ from pathlib import Path
 from typing import Optional
 from unittest.mock import MagicMock
 
+import patito as pt
 import polars as pl
 import pytest
 from typing_extensions import Literal
-
-import patito as pt
 
 # Skip test module if DuckDB is not installed
 if not pt._DUCKDB_AVAILABLE:
@@ -587,7 +586,7 @@ def test_fill_missing_columns():
 
     # Now we fill in the b column with "default_value"
     filled_defaults = relation.with_missing_defaultable_columns()
-    assert filled_defaults.set_model(None).get().dict() == {
+    assert filled_defaults.set_model(None).get().model_dump() == {
         "a": "mandatory",
         "b": "default_value",
         "d": 10.5,
@@ -600,14 +599,14 @@ def test_fill_missing_columns():
 
     # We now exclude the b column from being filled with default values
     excluded_default = relation.with_missing_defaultable_columns(exclude=["b"])
-    assert excluded_default.set_model(None).get().dict() == {
+    assert excluded_default.set_model(None).get().model_dump() == {
         "a": "mandatory",
         "d": 10.5,
     }
 
     # We can also specify that we only want to fill a subset
     included_defualts = relation.with_missing_defaultable_columns(include=["b"])
-    assert included_defualts.set_model(None).get().dict() == {
+    assert included_defualts.set_model(None).get().model_dump() == {
         "a": "mandatory",
         "b": "default_value",
         "d": 10.5,
@@ -615,7 +614,7 @@ def test_fill_missing_columns():
 
     # We now exclude column b and c from being filled with null values
     excluded_nulls = relation.with_missing_nullable_columns(exclude=["b", "c"])
-    assert excluded_nulls.set_model(None).get().dict() == {
+    assert excluded_nulls.set_model(None).get().model_dump() == {
         "a": "mandatory",
         "d": 10.5,
         "e": None,
@@ -623,7 +622,7 @@ def test_fill_missing_columns():
 
     # Only specify that we want to fill column e with nulls
     included_nulls = relation.with_missing_nullable_columns(include=["e"])
-    assert included_nulls.set_model(None).get().dict() == {
+    assert included_nulls.set_model(None).get().model_dump() == {
         "a": "mandatory",
         "d": 10.5,
         "e": None,

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -2,11 +2,10 @@
 from datetime import date, datetime
 from typing import Optional
 
+import patito as pt
 import polars as pl
 import pytest
 from typing_extensions import Literal
-
-import patito as pt
 
 
 def test_model_example_df():
@@ -66,7 +65,7 @@ def test_examples():
         MyModel.examples([[1, 2]])
 
 
-@pytest.mark.skipif("Database" not in dir(pt), reason="Requires DuckDB")
+@pytest.mark.skipif(not pt._DUCKDB_AVAILABLE, reason="Requires DuckDB")
 def test_creation_of_empty_relation():
     """You should be able to create a zero-row relation with correct types."""
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -224,7 +224,7 @@ def test_derive_functionality():
 
     # Non-compatible derive_from arguments should raise TypeError
     class InvalidModel(pt.Model):
-        incompatible: int = pt.Field(derived_from=object)
+        incompatible: int = pt.Field(derived_from=object)  # type: ignore
 
     with pytest.raises(
         TypeError,


### PR DESCRIPTION
Hello!

First off, apologies that this has taken so long. Put briefly, Jakob wrote patito, but has since moved on from our company. We have quite a bit of data science code that relies on it, so I am motivated to help maintain the project. Unfortunately, @JakobGM and I both have a lot on our plates, and patito has so far fallen lower on our priority list.

That's hopefully changing now. @JakobGM still has too much to do, but I've got some time.

This PR is still a draft, but I decided it was more than high time to actually publish our changes, compare with the absolutely awesome work @brendancooley has been doing, and get a new version out.

The status on this at time of publishing this draft is that the core pydantic 2 support is implemented for polars, but not for duckdb. If there are users of patito who are dependent on the duckdb functionality, I encourage you to speak up, since I'm considering removing support for it if it turns out to be hard to support (we've just disabled those tests locally so far)

@brendancooley, I'm particularly eyeing up your DataFrameValidationError - that was one of the pain points we had upgarding this.

Tests aren't fully passing yet, nor is all typing complete.