### PR TITLE
Fix some warnings after migration

### DIFF
--- a/src/patito/_pydantic/dtypes/dtypes.py
+++ b/src/patito/_pydantic/dtypes/dtypes.py
@@ -27,9 +27,11 @@ def valid_dtypes_for_model(
     cls: Type[ModelType],
 ) -> Mapping[str, FrozenSet[DataTypeClass]]:
     return {
-        column: DtypeResolver(cls.model_fields[column].annotation).valid_polars_dtypes()
-        if cls.column_infos[column].dtype is None
-        else DataTypeGroup([cls.dtypes[column]], match_base_type=False)
+        column: (
+            DtypeResolver(cls.model_fields[column].annotation).valid_polars_dtypes()
+            if cls.column_infos[column].dtype is None
+            else DataTypeGroup([cls.dtypes[column]], match_base_type=False)
+        )
         for column in cls.columns
     }
 

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -183,6 +183,17 @@ class LazyFrame(pl.LazyFrame, Generic[ModelType]):
         return df, derived_columns
 
     def unalias(self: LDF) -> LDF:
+        """Un-aliases column names using information from pydantic validation_alias.
+
+        In order of preference - model field name then validation_aliases in order of occurrence
+
+        limitation - AliasChoice validation type only supports selecting a single element of an array
+
+        Returns
+        -------
+            DataFrame[Model]: A dataframe with columns normalized to model names.
+
+        """
         if not any(fi.validation_alias for fi in self.model.model_fields.values()):
             return self
         exprs = []
@@ -233,6 +244,47 @@ class LazyFrame(pl.LazyFrame, Generic[ModelType]):
     def cast(
         self: LDF, strict: bool = False, columns: Optional[Sequence[str]] = None
     ) -> LDF:
+        """Cast columns to `dtypes` specified by the associated Patito model.
+
+        Args:
+        ----
+            strict: If set to ``False``, columns which are technically compliant with
+                the specified field type, will not be casted. For example, a column
+                annotated with ``int`` is technically compliant with ``pl.UInt8``, even
+                if ``pl.Int64`` is the default dtype associated with ``int``-annotated
+                fields. If ``strict`` is set to ``True``, the resulting dtypes will
+                be forced to the default dtype associated with each python type.
+            columns: Optionally, a list of column names to cast. If not provided, all
+                columns are casted.
+
+        Returns:
+        -------
+            LazyFrame[Model]: A dataframe with columns casted to the correct dtypes.
+
+        Examples:
+        --------
+            Create a simple model:
+
+            >>> import patito as pt
+            >>> import polars as pl
+            >>> class Product(pt.Model):
+            ...     name: str
+            ...     cent_price: int = pt.Field(dtype=pl.UInt16)
+            ...
+
+            Now we can use this model to cast some simple data:
+
+            >>> Product.LazyFrame({"name": ["apple"], "cent_price": ["8"]}).cast().collect()
+            shape: (1, 2)
+            ┌───────┬────────────┐
+            │ name  ┆ cent_price │
+            │ ---   ┆ ---        │
+            │ str   ┆ u16        │
+            ╞═══════╪════════════╡
+            │ apple ┆ 8          │
+            └───────┴────────────┘
+
+        """
         properties = self.model._schema_properties()
         valid_dtypes = self.model.valid_dtypes
         default_dtypes = self.model.dtypes
@@ -251,7 +303,7 @@ class LazyFrame(pl.LazyFrame, Generic[ModelType]):
 
     @classmethod
     def from_existing(cls: Type[LDF], lf: pl.LazyFrame) -> LDF:
-        """Constructs a patito.DataFrame object from an existing polars.DataFrame object"""
+        """Construct a patito.DataFrame object from an existing polars.DataFrame object."""
         return cls.model.LazyFrame._from_pyldf(lf._ldf).cast()
 
 
@@ -422,6 +474,8 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
                 if ``pl.Int64`` is the default dtype associated with ``int``-annotated
                 fields. If ``strict`` is set to ``True``, the resulting dtypes will
                 be forced to the default dtype associated with each python type.
+            columns: Optionally, a list of column names to cast. If not provided, all
+                columns are casted.
 
         Returns:
         -------
@@ -784,6 +838,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
         )
 
     def as_polars(self) -> pl.DataFrame:
+        """Convert patito dataframe to polars dataframe."""
         return pl.DataFrame._from_pydf(self._df)
 
     @classmethod

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -83,7 +83,8 @@ class LazyFrame(pl.LazyFrame, Generic[ModelType]):
         See documentation of polars.DataFrame.collect for full description of
         parameters.
         """
-        df = super().collect(*args, **kwargs)
+        background = kwargs.pop("background", False)
+        df = super().collect(*args, background=background, **kwargs)
         if getattr(self, "model", False):
             cls = DataFrame._construct_dataframe_model_class(model=self.model)
         else:

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -69,7 +69,7 @@ ModelType = TypeVar("ModelType", bound="Model")
 
 
 class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
-    """Metclass used by patito.Model.
+    """Metaclass used by patito.Model.
 
     Responsible for setting any relevant model-dependent class properties.
     """
@@ -129,7 +129,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return schema_for_model(cls)
 
     @property
-    def columns(cls: Type[ModelType]) -> List[str]:  # type: ignore
+    def columns(cls: Type[ModelType]) -> List[str]:
         """Return the name of the dataframe columns specified by the fields of the model.
 
         Returns:
@@ -150,9 +150,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return list(cls.model_fields.keys())
 
     @property
-    def dtypes(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, DataTypeClass | DataType]:
+    def dtypes(cls: Type[ModelType]) -> dict[str, DataTypeClass | DataType]:
         """Return the polars dtypes of the dataframe.
 
         Unless Field(dtype=...) is specified, the highest signed column dtype
@@ -177,8 +175,8 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return default_dtypes_for_model(cls)
 
     @property
-    def valid_dtypes(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
+    def valid_dtypes(
+        cls: Type[ModelType],
     ) -> Mapping[str, FrozenSet[DataTypeClass | DataType]]:
         """Return a list of polars dtypes which Patito considers valid for each field.
 
@@ -223,9 +221,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return valid_dtypes_for_model(cls)
 
     @property
-    def defaults(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
-    ) -> dict[str, Any]:
+    def defaults(cls: Type[ModelType]) -> dict[str, Any]:
         """Return default field values specified on the model.
 
         Returns:
@@ -252,9 +248,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         }
 
     @property
-    def non_nullable_columns(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
-    ) -> set[str]:
+    def non_nullable_columns(cls: Type[ModelType]) -> set[str]:
         """Return names of those columns that are non-nullable in the schema.
 
         Returns:

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -279,9 +279,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         )
 
     @property
-    def nullable_columns(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
-    ) -> set[str]:
+    def nullable_columns(cls: Type[ModelType]) -> set[str]:
         """Return names of those columns that are nullable in the schema.
 
         Returns:
@@ -305,9 +303,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return set(cls.columns) - cls.non_nullable_columns
 
     @property
-    def unique_columns(  # type: ignore
-        cls: Type[ModelType],  # pyright: ignore
-    ) -> set[str]:
+    def unique_columns(cls: Type[ModelType]) -> set[str]:
         """Return columns with uniqueness constraint.
 
         Returns:
@@ -332,9 +328,7 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
         return {column for column in cls.columns if infos[column].unique}
 
     @property
-    def derived_columns(
-        cls: Type[ModelType],  # type: ignore[misc]
-    ) -> set[str]:
+    def derived_columns(cls: Type[ModelType]) -> set[str]:
         """Return set of columns which are derived from other columns."""
         infos = cls.column_infos
         return {
@@ -360,7 +354,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
     @classmethod
     def from_row(
-        cls: Type[ModelType],  # type: ignore[misc]
+        cls: Type[ModelType],
         row: Union["pd.DataFrame", pl.DataFrame],
         validate: bool = True,
     ) -> ModelType:
@@ -404,7 +398,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             dataframe = row
         elif _PANDAS_AVAILABLE and isinstance(row, pd.DataFrame):
             dataframe = pl.DataFrame._from_pandas(row)
-        elif _PANDAS_AVAILABLE and isinstance(row, pd.Series):  # type: ignore[unreachable]
+        elif _PANDAS_AVAILABLE and isinstance(row, pd.Series):
             return cls(**dict(row.items()))  # type: ignore[unreachable]
         else:
             raise TypeError(f"{cls.__name__}.from_row not implemented for {type(row)}.")
@@ -1326,7 +1320,7 @@ FIELD_KWARGS = getfullargspec(fields.Field)
 
 
 def FieldCI(
-    column_info: CI, *args: Any, **kwargs: Any
+    column_info: Type[ColumnInfo], *args: Any, **kwargs: Any
 ) -> Any:  # annotate with Any to make the downstream type annotations happy
     ci = column_info(**kwargs)
     for field in ci.model_fields_set:

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -182,40 +182,14 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
 
         The first item of each list is the default dtype chosen by Patito.
 
-        Returns:
+        Returns
         -------
             A dictionary mapping each column string name to a list of valid dtypes.
 
-        Raises:
+        Raises
         ------
             NotImplementedError: If one or more model fields are annotated with types
                 not compatible with polars.
-
-        Example:
-        -------
-            >>> from pprint import pprint
-            >>> import patito as pt
-
-            >>> class MyModel(pt.Model):
-            ...     bool_column: bool
-            ...     str_column: str
-            ...     int_column: int
-            ...     float_column: float
-            ...
-            >>> pprint(MyModel.valid_dtypes)
-            {'bool_column': DataTypeGroup({Boolean}),
-            'float_column': DataTypeGroup({Float64, Float32}),
-            'int_column': DataTypeGroup({Int8,
-                                        Int16,
-                                        Int32,
-                                        Int64,
-                                        UInt8,
-                                        UInt16,
-                                        UInt32,
-                                        UInt64,
-                                        Float32,
-                                        Float64}),
-            'str_column': DataTypeGroup({String})}
 
         """
         return valid_dtypes_for_model(cls)


### PR DESCRIPTION
I'm fixing some of the warnings introduced with the pydantic PR. Mainly adding docstrings where we had duplicates to copy from elsewhere, but also some minor typing things.