### PR TITLE
feat: use model field alias generator appropriately for CSV column names

### DIFF
--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -866,8 +867,22 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
 
         """
         kwargs.setdefault("dtypes", cls.model.dtypes)
-        if not kwargs.get("has_header", True) and "columns" not in kwargs:
+        has_header = kwargs.get("has_header", True)
+        if not has_header and "columns" not in kwargs:
             kwargs.setdefault("new_columns", cls.model.columns)
+        alias_gen = cls.model.model_config.get("alias_generator")
+        if alias_gen:
+            alias_func = alias_gen.validation_alias or alias_gen.alias
+        if has_header and alias_gen and alias_func:
+            fields_to_cols = {
+                field_name: alias_func(field_name)
+                for field_name in cls.model.model_fields
+            }
+            kwargs["dtypes"] = {
+                fields_to_cols.get(field, field): dtype
+                for field, dtype in kwargs["dtypes"].items()
+            }
+            # TODO: other forms of alias setting like in Field
         df = cls.model.DataFrame._from_pydf(pl.read_csv(*args, **kwargs)._df)
         return df.derive()
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -1240,6 +1240,7 @@ FIELD_KWARGS = getfullargspec(fields.Field)
 
 # Helper function for patito Field.
 
+
 def FieldCI(
     column_info: Type[ColumnInfo], *args: Any, **kwargs: Any
 ) -> Any:  # annotate with Any to make the downstream type annotations happy
@@ -1253,6 +1254,7 @@ def FieldCI(
     can be read with the below examples.
 
     Args:
+        column_info: (Type[ColumnInfo]): ColumnInfo object to pass args to.
         constraints (Union[polars.Expression, List[polars.Expression]): A single
             constraint or list of constraints, expressed as a polars expression objects.
             All rows must satisfy the given constraint. You can refer to the given column
@@ -1274,6 +1276,8 @@ def FieldCI(
         regex (str): UTF-8 string column must match regex pattern for all row values.
         min_length (int): Minimum length of all string values in a UTF-8 column.
         max_length (int): Maximum length of all string values in a UTF-8 column.
+        args (Any): additional arguments to pass to pydantic's field.
+        kwargs (Any): additional keyword arguments to pass to pydantic's field.
 
     Return:
         `FieldInfo <https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.FieldInfo>`_:

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -420,7 +420,9 @@ def test_derive_subset() -> None:
             "expr_derived": [2, 4],
         }
     )
-    assert df.derive(columns=["expr_derived"]).equals(
+    assert df.derive(
+        columns=["expr_derived"]
+    ).equals(
         correct_derived_df
     )  # only include "expr_derived" in output, but ensure that "derived" was derived recursively
 
@@ -563,6 +565,8 @@ def test_validation_alias() -> None:
 
 
 def test_alias_generator_read_csv() -> None:
+    """Ensure validation alias is applied to read_csv."""
+
     class AliasGeneratorModel(pt.Model):
         model_config = ConfigDict(
             alias_generator=AliasGenerator(validation_alias=str.title),

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1,5 +1,7 @@
 """Tests related to polars functionality."""
 
+from __future__ import annotations
+
 import re
 from datetime import date, datetime
 from io import StringIO

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1,7 +1,5 @@
 """Tests related to polars functionality."""
 
-from __future__ import annotations
-
 import re
 from datetime import date, datetime
 from io import StringIO
@@ -571,7 +569,7 @@ def test_alias_generator_read_csv() -> None:
         )
 
         My_Val_A: int
-        My_Val_B: int | None = None
+        My_Val_B: Optional[int] = None
 
     csv_data = StringIO("my_val_a,my_val_b\n1,")
     df = AliasGeneratorModel.DataFrame.read_csv(csv_data)


### PR DESCRIPTION
If the header is to be read by the Polars CSV reader, and if the Pydantic model has an alias generator, then the columns should be expected to be given by applying the aliasing function on the model fields.

This solves the issue reported in:

- #55