### PR TITLE
Add tests for AliasGenerator

### DIFF
--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -76,12 +76,15 @@ def _dewrap_optional(type_annotation: Type[Any] | Any) -> Type:
 def _transform_df(dataframe: pl.DataFrame, schema: type[Model]) -> pl.DataFrame:
     """Transform any properties of the dataframe according to the model.
 
+    Currently only supports using AliasGenerator to transform column names to match a model.
+
     Args:
     ----
         dataframe: Polars DataFrame to be validated.
         schema: Patito model which specifies how the dataframe should be structured.
 
     """
+    # Check if an alias generator is present in model_config
     if alias_gen := schema.model_config.get("alias_generator"):
         if isinstance(alias_gen, AliasGenerator):
             alias_func = alias_gen.validation_alias or alias_gen.alias


### PR DESCRIPTION
I accidentally added the support for [AliasGenerator](https://docs.pydantic.dev/latest/concepts/alias/) within PR #58 after reading @llmx issue in #55. I'm now adding a few tests.

This supports transforming column names of a df to match those of a patito model using either a function with signature `[str] -> str` or an [AliasGenerator](https://docs.pydantic.dev/latest/concepts/alias/).