### PR TITLE
Add iterators

### DIFF
--- a/src/patito/exceptions.py
+++ b/src/patito/exceptions.py
@@ -208,7 +208,3 @@ class RowDoesNotExist(RuntimeError):
 
 class MultipleRowsReturned(RuntimeError):
     """Exception for when a single row was expected, but several were returned."""
-
-
-class ModelRequiredError(ValueError):
-    """Exception for when a model is required but not found."""

--- a/src/patito/exceptions.py
+++ b/src/patito/exceptions.py
@@ -208,3 +208,7 @@ class RowDoesNotExist(RuntimeError):
 
 class MultipleRowsReturned(RuntimeError):
     """Exception for when a single row was expected, but several were returned."""
+
+
+class ModelRequiredError(ValueError):
+    """Exception for when a model is required but not found."""

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -836,7 +836,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
                 f"before invoking {self.__class__.__name__}.iter_models()."
             )
 
-        df = self.validate(filter_columns=True) if validate_df else self
+        df = self.validate(drop_superfluous_columns=True) if validate_df else self
 
         def _iter_models(_df: DF) -> Iterator[ModelType]:
             for idx in range(_df.height):

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -43,11 +43,6 @@ class ListableIterator(Iterator[T], Generic[T]):
         """Construct a ListableIterator from an iterator."""
         self._iterator = iterator
 
-    @classmethod
-    def from_iterator(cls, iterable: Iterator[T]) -> "ListableIterator[T]":
-        """Construct a ListableIterator from an iterable."""
-        return cls(iter(iterable))
-
     def to_list(self) -> list[T]:
         """Convert iterator to list."""
         return list(self)

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -844,40 +844,6 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
 
         return ModelGenerator(_iter_models(df))
 
-    def to_list(self, **kwargs) -> list[ModelType]:
-        """Convert the dataframe to a list of pydantic models.
-
-        Args:
-            **kwargs: Additional keyword arguments are forwarded to the validation
-
-        Returns:
-            List[Model]: A list of pydantic-derived models representing the rows in the
-                dataframe.
-
-        Raises:
-            TypeError: If ``DataFrame.set_model()`` has not been invoked prior to
-                iteration.
-
-        Example:
-            >>> import patito as pt
-            >>> import polars as pl
-            >>> class Product(pt.Model):
-            ...     product_id: int = pt.Field(unique=True)
-            ...     price: float
-            ...
-            >>> df = pt.DataFrame({"product_id": [1, 2], "price": [10, 20]})
-            >>> df.set_model(Product)
-            >>> df.to_list()
-            [Product(product_id=1, price=10.0), Product(product_id=2, price=20.0)]
-
-        """
-        if not hasattr(self, "model"):
-            raise TypeError(
-                f"You must invoke {self.__class__.__name__}.set_model() "
-                f"before invoking {self.__class__.__name__}.to_list()."
-            )
-        return self.iter_models(**kwargs).to_list()
-
     def _pydantic_model(self) -> Type[Model]:
         """Dynamically construct patito model compliant with dataframe.
 

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -36,21 +36,21 @@ OtherModelType = TypeVar("OtherModelType", bound="Model")
 T = TypeVar("T")
 
 
-class ListableIterator(Iterator[T], Generic[T]):
+class ModelGenerator(Iterator[ModelType], Generic[ModelType]):
     """An iterator that can be converted to a list."""
 
-    def __init__(self, iterator: Iterator[T]):
-        """Construct a ListableIterator from an iterator."""
+    def __init__(self, iterator: Iterator[ModelType]) -> None:
+        """Construct a ModelGenerator from an iterator."""
         self._iterator = iterator
 
-    def to_list(self) -> list[T]:
+    def to_list(self) -> list[ModelType]:
         """Convert iterator to list."""
         return list(self)
 
-    def __next__(self) -> T:  # noqa: D105
+    def __next__(self) -> ModelType:  # noqa: D105
         return next(self._iterator)
 
-    def __iter__(self) -> Iterator[T]:  # noqa: D105
+    def __iter__(self) -> Iterator[ModelType]:  # noqa: D105
         return self
 
 
@@ -796,7 +796,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
 
     def iter_models(
         self, validate_df: bool = True, validate_model: bool = False
-    ) -> ListableIterator[ModelType]:
+    ) -> ModelGenerator[ModelType]:
         """Iterate over all rows in the dataframe as pydantic models.
 
         Args:
@@ -842,7 +842,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
             for idx in range(_df.height):
                 yield self.model.from_row(_df[idx], validate=validate_model)
 
-        return ListableIterator(_iter_models(df))
+        return ModelGenerator(_iter_models(df))
 
     def to_list(self, **kwargs) -> list[ModelType]:
         """Convert the dataframe to a list of pydantic models.

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -847,7 +847,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
             df = self
 
         def _iter_models(_df: DF) -> Iterator[ModelType]:
-            for idx in range(df.height):
+            for idx in range(_df.height):
                 yield self.model.from_row(_df[idx], validate=validate_model)
 
         return ListableIterator(_iter_models(df))

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -841,10 +841,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
                 f"before invoking {self.__class__.__name__}.iter_models()."
             )
 
-        if validate_df:
-            df = self.validate(filter_columns=True)
-        else:
-            df = self
+        df = self.validate(filter_columns=True) if validate_df else self
 
         def _iter_models(_df: DF) -> Iterator[ModelType]:
             for idx in range(_df.height):

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -50,7 +50,7 @@ from patito._pydantic.dtypes import (
     validate_polars_dtype,
 )
 from patito._pydantic.schema import column_infos_for_model, schema_for_model
-from patito.polars import DataFrame, LazyFrame, ListableIterator
+from patito.polars import DataFrame, LazyFrame, ModelGenerator
 from patito.validators import validate
 
 try:
@@ -486,7 +486,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
     @classmethod
     def iter(
         cls: Type[ModelType], dataframe: Union["pd.DataFrame", pl.DataFrame]
-    ) -> ListableIterator[ModelType]:
+    ) -> ModelGenerator[ModelType]:
         """Validate the dataframe and iterate over the rows, yielding Patito models.
 
         Args:

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -425,7 +425,6 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         allow_missing_columns: bool = False,
         allow_superfluous_columns: bool = False,
         filter_columns: bool = False,
-        **kwargs,
     ) -> DataFrame[ModelType]:
         """Validate the schema and content of the given dataframe.
 
@@ -436,10 +435,9 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             allow_missing_columns: If True, missing columns will not be considered an error.
             allow_superfluous_columns: If True, additional columns will not be considered an error.
             filter_columns: If True, only columns specified in the model will be validated.
-            **kwargs: Additional keyword arguments to be passed to the validation
 
         Returns:
-            DataFrame: A Patito DataFrame containing the validated data.
+            DataFrame: A patito DataFrame containing the validated data.
 
         Raises:
             patito.exceptions.DataFrameValidationError: If the given dataframe does not match
@@ -482,26 +480,43 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             allow_missing_columns=allow_missing_columns,
             allow_superfluous_columns=allow_superfluous_columns,
             filter_columns=filter_columns,
-            **kwargs,
         )
         return cls.DataFrame(dataframe)
 
     @classmethod
     def iter(
-        cls: Type[ModelType], dataframe: pl.DataFrame, cast_types: bool = False
+        cls: Type[ModelType], dataframe: Union["pd.DataFrame", pl.DataFrame]
     ) -> ListableIterator[ModelType]:
-        """Validate the dataframe and iterate over the rows, yielding Patito models."""
-        validated = cls.validate(dataframe, filter_columns=True)
-        if cast_types:
-            validated = validated.cast()
-        return validated.iter_models(validate=False)
+        """Validate the dataframe and iterate over the rows, yielding Patito models.
+
+        Args:
+            dataframe: Polars or pandas DataFrame to be validated.
+
+        Returns:
+            ListableIterator: An iterator of patito models over the validated data.
+
+        Raises:
+            patito.exceptions.DataFrameValidationError: If the given dataframe does not match
+                the given schema.
+
+        """
+        return cls.DataFrame(dataframe).iter_models()
 
     @classmethod
     def to_list(
-        cls: Type[ModelType], dataframe: pl.DataFrame, cast_types: bool = False
+        cls: Type[ModelType], dataframe: Union["pd.DataFrame", pl.DataFrame]
     ) -> List[ModelType]:
-        """Validate the dataframe and return a list of Patito models."""
-        return cls.iter(dataframe, cast_types=cast_types).to_list()
+        """Validate the dataframe and return a list of Patito models.
+
+        Args:
+            dataframe:
+                Polars or pandas DataFrame to be validated.
+
+        Returns:
+            List[Model]: A list of patito models over the validated data.
+
+        """
+        return cls.DataFrame(dataframe).to_list()
 
     @classmethod
     def example_value(  # noqa: C901

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -484,7 +484,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return cls.DataFrame(dataframe)
 
     @classmethod
-    def iter(
+    def iter_models(
         cls: Type[ModelType], dataframe: Union["pd.DataFrame", pl.DataFrame]
     ) -> ModelGenerator[ModelType]:
         """Validate the dataframe and iterate over the rows, yielding Patito models.

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -503,22 +503,6 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return cls.DataFrame(dataframe).iter_models()
 
     @classmethod
-    def to_list(
-        cls: Type[ModelType], dataframe: Union["pd.DataFrame", pl.DataFrame]
-    ) -> List[ModelType]:
-        """Validate the dataframe and return a list of Patito models.
-
-        Args:
-            dataframe:
-                Polars or pandas DataFrame to be validated.
-
-        Returns:
-            List[Model]: A list of patito models over the validated data.
-
-        """
-        return cls.DataFrame(dataframe).to_list()
-
-    @classmethod
     def example_value(  # noqa: C901
         cls,
         field: Optional[str] = None,

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -424,7 +424,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         columns: Optional[Sequence[str]] = None,
         allow_missing_columns: bool = False,
         allow_superfluous_columns: bool = False,
-        filter_columns: bool = False,
+        drop_superfluous_columns: bool = False,
     ) -> DataFrame[ModelType]:
         """Validate the schema and content of the given dataframe.
 
@@ -434,7 +434,8 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 of the dataframe will be validated.
             allow_missing_columns: If True, missing columns will not be considered an error.
             allow_superfluous_columns: If True, additional columns will not be considered an error.
-            filter_columns: If True, only columns specified in the model will be validated.
+            drop_superfluous_columns: If True, columns not present in the model will be
+                dropped from the resulting dataframe.
 
         Returns:
             DataFrame: A patito DataFrame containing the validated data.
@@ -479,7 +480,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             columns=columns,
             allow_missing_columns=allow_missing_columns,
             allow_superfluous_columns=allow_superfluous_columns,
-            filter_columns=filter_columns,
+            drop_superfluous_columns=drop_superfluous_columns,
         )
         return cls.DataFrame(dataframe)
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -439,7 +439,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             **kwargs: Additional keyword arguments to be passed to the validation
 
         Returns:
-            ``None``:
+            DataFrame: A Patito DataFrame containing the validated data.
 
         Raises:
             patito.exceptions.DataFrameValidationError: If the given dataframe does not match
@@ -484,10 +484,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             filter_columns=filter_columns,
             **kwargs,
         )
-        return DataFrame(dataframe).set_model(cls)
+        return cls.DataFrame(dataframe)
 
     @classmethod
-    def iterate(
+    def iter(
         cls: Type[ModelType], dataframe: pl.DataFrame, cast_types: bool = False
     ) -> ListableIterator[ModelType]:
         """Validate the dataframe and iterate over the rows, yielding Patito models."""
@@ -497,11 +497,11 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         return validated.iter_models(validate=False)
 
     @classmethod
-    def as_list(
+    def to_list(
         cls: Type[ModelType], dataframe: pl.DataFrame, cast_types: bool = False
     ) -> List[ModelType]:
         """Validate the dataframe and return a list of Patito models."""
-        return cls.iterate(dataframe, cast_types=cast_types).as_list()
+        return cls.iter(dataframe, cast_types=cast_types).to_list()
 
     @classmethod
     def example_value(  # noqa: C901

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -370,9 +370,9 @@ def _find_errors(  # noqa: C901
             custom_constraints = column_info.constraints
             if isinstance(custom_constraints, pl.Expr):
                 custom_constraints = [custom_constraints]
-            constraints = pl.any_horizontal(
-                [constraint.not_() for constraint in custom_constraints]
-            )
+            constraints = pl.any_horizontal([
+                constraint.not_() for constraint in custom_constraints
+            ])
             if "_" in constraints.meta.root_names():
                 # An underscore is an alias for the current field
                 illegal_rows = dataframe_tmp.with_columns(
@@ -460,11 +460,9 @@ def validate(
 
     polars_dataframe = _transform_df(polars_dataframe, schema)
 
-    if filter_columns:
+    if not columns and filter_columns:
         # NOTE: dropping rather than selecting to get the correct error messages
-        schema_subset = columns or schema.columns
-        column_subset = columns or dataframe.columns
-        to_drop = set(column_subset) - set(schema_subset)
+        to_drop = set(dataframe.columns) - set(schema.columns)
         polars_dataframe = polars_dataframe.drop(to_drop)
 
     errors = _find_errors(

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -453,6 +453,9 @@ def validate(
         DataFrameValidationError: If the given dataframe does not match the given schema.
 
     """
+    if filter_columns and columns:
+        raise ValueError("Cannot specify both 'columns' and 'filter_columns'.")
+
     if _PANDAS_AVAILABLE and isinstance(dataframe, pd.DataFrame):
         polars_dataframe = pl.from_pandas(dataframe)
     else:
@@ -460,7 +463,7 @@ def validate(
 
     polars_dataframe = _transform_df(polars_dataframe, schema)
 
-    if not columns and filter_columns:
+    if filter_columns:
         # NOTE: dropping rather than selecting to get the correct error messages
         to_drop = set(dataframe.columns) - set(schema.columns)
         polars_dataframe = polars_dataframe.drop(to_drop)

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -370,9 +370,9 @@ def _find_errors(  # noqa: C901
             custom_constraints = column_info.constraints
             if isinstance(custom_constraints, pl.Expr):
                 custom_constraints = [custom_constraints]
-            constraints = pl.any_horizontal([
-                constraint.not_() for constraint in custom_constraints
-            ])
+            constraints = pl.any_horizontal(
+                [constraint.not_() for constraint in custom_constraints]
+            )
             if "_" in constraints.meta.root_names():
                 # An underscore is an alias for the current field
                 illegal_rows = dataframe_tmp.with_columns(

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -436,7 +436,7 @@ def validate(
     columns: Optional[Sequence[str]] = None,
     allow_missing_columns: bool = False,
     allow_superfluous_columns: bool = False,
-    filter_columns: bool = False,
+    drop_superfluous_columns: bool = False,
 ) -> pl.DataFrame:
     """Validate the given dataframe.
 
@@ -447,14 +447,16 @@ def validate(
             of the dataframe will be validated.
         allow_missing_columns: If True, missing columns will not be considered an error.
         allow_superfluous_columns: If True, additional columns will not be considered an error.
-        filter_columns: If True, drop any columns not specified in the schema before validation.
+        drop_superfluous_columns: If True, drop any columns not specified in the schema before validation.
 
     Raises:
         DataFrameValidationError: If the given dataframe does not match the given schema.
 
     """
-    if filter_columns and columns:
-        raise ValueError("Cannot specify both 'columns' and 'filter_columns'.")
+    if drop_superfluous_columns and columns:
+        raise ValueError(
+            "Cannot specify both 'columns' and 'drop_superfluous_columns'."
+        )
 
     if _PANDAS_AVAILABLE and isinstance(dataframe, pd.DataFrame):
         polars_dataframe = pl.from_pandas(dataframe)
@@ -463,7 +465,7 @@ def validate(
 
     polars_dataframe = _transform_df(polars_dataframe, schema)
 
-    if filter_columns:
+    if drop_superfluous_columns:
         # NOTE: dropping rather than selecting to get the correct error messages
         to_drop = set(dataframe.columns) - set(schema.columns)
         polars_dataframe = polars_dataframe.drop(to_drop)

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -437,7 +437,7 @@ def validate(
     allow_missing_columns: bool = False,
     allow_superfluous_columns: bool = False,
     filter_columns: bool = False,
-) -> None:
+) -> pl.DataFrame:
     """Validate the given dataframe.
 
     Args:
@@ -476,3 +476,5 @@ def validate(
     )
     if errors:
         raise DataFrameValidationError(errors=errors, model=schema)
+
+    return polars_dataframe

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -146,7 +146,7 @@ def test_instantiating_model_from_row() -> None:
         Model._from_polars(None)  # pyright: ignore
 
 
-def test_insstantiation_from_pandas_row() -> None:
+def test_instantiation_from_pandas_row() -> None:
     """You should be able to instantiate models from pandas rows."""
     pytest.importorskip("pandas")
 
@@ -558,23 +558,24 @@ def test_validation_returns_df():  # noqa: D103
 
 
 def test_model_iter_works():  # noqa: D103
-    for Model in [SmallModel, ManyTypes, CompleteModel]:
-        df = Model.examples()
-        for _ in range(5):
-            df = df.vstack(Model.examples())
+    class SingleColumnModel(pt.Model):
+        a: int
 
-        full_list = []
-        for row in Model.iter(df):
-            assert isinstance(row, Model)
-            full_list.append(row)
-        assert len(full_list) == len(df)
+    df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
+
+    full_list = []
+    for row in SingleColumnModel.iter(df):
+        assert isinstance(row, SingleColumnModel)
+        full_list.append(row)
+    assert len(full_list) == len(df)
 
 
 def test_model_to_list_works():  # noqa: D103
-    for Model in [SmallModel, ManyTypes, CompleteModel]:
-        df = Model.examples()
-        for _ in range(5):
-            df = df.vstack(Model.examples())
+    class SingleColumnModel(pt.Model):
+        a: int
 
-        full_list = Model.to_list(df)
-        assert len(full_list) == len(df)
+    df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
+    full_list = SingleColumnModel.to_list(df)
+    assert len(full_list) == len(df)
+    for model_instance in full_list:
+        assert isinstance(model_instance, SingleColumnModel)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -557,7 +557,7 @@ def test_validation_returns_df():  # noqa: D103
         assert_frame_equal(remade_model, df)
 
 
-def test_model_iter_models_works():  # noqa: D103
+def test_model_iter_models():  # noqa: D103
     class SingleColumnModel(pt.Model):
         a: int
 
@@ -570,7 +570,7 @@ def test_model_iter_models_works():  # noqa: D103
     assert len(full_list) == len(df)
 
 
-def test_model_iter_models_to_list_works():  # noqa: D103
+def test_model_iter_models_to_list():  # noqa: D103
     class SingleColumnModel(pt.Model):
         a: int
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -570,12 +570,12 @@ def test_model_iter_works():  # noqa: D103
     assert len(full_list) == len(df)
 
 
-def test_model_to_list_works():  # noqa: D103
+def test_model_iter_to_list_works():  # noqa: D103
     class SingleColumnModel(pt.Model):
         a: int
 
     df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
-    full_list = SingleColumnModel.to_list(df)
+    full_list = SingleColumnModel.iter(df).to_list()
     assert len(full_list) == len(df)
     for model_instance in full_list:
         assert isinstance(model_instance, SingleColumnModel)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -557,25 +557,25 @@ def test_validation_returns_df():  # noqa: D103
         assert_frame_equal(remade_model, df)
 
 
-def test_model_iter_works():  # noqa: D103
+def test_model_iter_models_works():  # noqa: D103
     class SingleColumnModel(pt.Model):
         a: int
 
     df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
 
     full_list = []
-    for row in SingleColumnModel.iter(df):
+    for row in SingleColumnModel.iter_models(df):
         assert isinstance(row, SingleColumnModel)
         full_list.append(row)
     assert len(full_list) == len(df)
 
 
-def test_model_iter_to_list_works():  # noqa: D103
+def test_model_iter_models_to_list_works():  # noqa: D103
     class SingleColumnModel(pt.Model):
         a: int
 
     df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
-    full_list = SingleColumnModel.iter(df).to_list()
+    full_list = SingleColumnModel.iter_models(df).to_list()
     assert len(full_list) == len(df)
     for model_instance in full_list:
         assert isinstance(model_instance, SingleColumnModel)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -564,9 +564,9 @@ def test_model_iter_models():  # noqa: D103
     df = SingleColumnModel.DataFrame({"a": [1, 2, 3]})
 
     full_list = []
-    for row in SingleColumnModel.iter_models(df):
-        assert isinstance(row, SingleColumnModel)
-        full_list.append(row)
+    for row_model in SingleColumnModel.iter_models(df):
+        assert isinstance(row_model, SingleColumnModel)
+        full_list.append(row_model)
     assert len(full_list) == len(df)
 
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -611,14 +611,14 @@ def test_iter_models() -> None:
     assert m2.a == 2
 
 
-def test_to_list() -> None:
+def test_iter_models_to_list() -> None:
     """Ensure to_list() returns a list of models."""
 
     class Model(pt.Model):
         a: int
 
     df = Model.DataFrame({"a": [1, 2]})
-    models = df.to_list()
+    models = df.iter_models().to_list()
     assert models[0].a == 1
     assert models[1].a == 2
     for model in models:

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -597,7 +597,8 @@ def test_iter_models() -> None:
     class Model(pt.Model):
         a: int
 
-    df = Model.DataFrame({"a": [1, 2]})
+    # Test with extra column to ensure column is dropped before validation
+    df = Model.DataFrame({"a": [1, 2], "b": [3, 4]})
     models = df.iter_models()
     m1 = next(models)
     m2 = next(models)

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -564,6 +564,16 @@ def test_validation_alias() -> None:
     assert df.columns == AliasModel.columns
 
 
+def test_validation_returns_df() -> None:
+    """Ensure DataFrame.validate() returns a DataFrame."""
+
+    class Model(pt.Model):
+        a: int
+
+    df = Model.DataFrame({"a": [1, 2]})
+    assert df.validate().equals(df)
+
+
 def test_alias_generator_read_csv() -> None:
     """Ensure validation alias is applied to read_csv."""
 
@@ -579,3 +589,36 @@ def test_alias_generator_read_csv() -> None:
     df = AliasGeneratorModel.DataFrame.read_csv(csv_data)
     df.validate()
     assert df.to_dicts() == [{"My_Val_A": 1, "My_Val_B": None}]
+
+
+def test_iter_models() -> None:
+    """Ensure iter_models() returns a generator of models."""
+
+    class Model(pt.Model):
+        a: int
+
+    df = Model.DataFrame({"a": [1, 2]})
+    models = df.iter_models()
+    m1 = next(models)
+    m2 = next(models)
+    with pytest.raises(StopIteration):
+        next(models)
+
+    assert isinstance(m1, Model)
+    assert isinstance(m2, Model)
+    assert m1.a == 1
+    assert m2.a == 2
+
+
+def test_to_list() -> None:
+    """Ensure to_list() returns a list of models."""
+
+    class Model(pt.Model):
+        a: int
+
+    df = Model.DataFrame({"a": [1, 2]})
+    models = df.to_list()
+    assert models[0].a == 1
+    assert models[1].a == 2
+    for model in models:
+        assert isinstance(model, Model)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -127,6 +127,19 @@ def test_superfluous_column_validation() -> None:
     )  # model-centric API also works
 
 
+def test_validate_filters_columns() -> None:
+    """Test whether irrelevant columns get filtered out before validation."""
+
+    class SingleColumnModel(pt.Model):
+        column_1: int
+
+    test_df = SingleColumnModel.examples().with_columns(
+        column_that_should_be_dropped=pl.Series([1])
+    )
+    result = validate(test_df, SingleColumnModel, filter_columns=True)
+    assert result.columns == ["column_1"]
+
+
 def test_validate_non_nullable_columns() -> None:
     """Test for validation logic related to missing values."""
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -53,6 +53,19 @@ def test_dewrap_optional_with_pipe_operator() -> None:
     )
 
 
+def test_validation_returns_df() -> None:
+    """It should return a DataFrame with the validation results."""
+
+    class SimpleModel(pt.Model):
+        column_1: int
+        column_2: str
+
+    df = pl.DataFrame({"column_1": [1, 2, 3], "column_2": ["a", "b", "c"]})
+    result = validate(dataframe=df, schema=SimpleModel)
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape == (3, 2)
+
+
 def test_missing_column_validation() -> None:
     """Validation should catch missing columns."""
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -140,7 +140,7 @@ def test_superfluous_column_validation() -> None:
     )  # model-centric API also works
 
 
-def test_validate_filters_columns() -> None:
+def test_drop_superfluous_columns() -> None:
     """Test whether irrelevant columns get filtered out before validation."""
 
     class SingleColumnModel(pt.Model):
@@ -149,7 +149,11 @@ def test_validate_filters_columns() -> None:
     test_df = SingleColumnModel.examples().with_columns(
         column_that_should_be_dropped=pl.Series([1])
     )
-    result = validate(test_df, SingleColumnModel, filter_columns=True)
+    result = validate(
+        test_df,
+        SingleColumnModel,
+        drop_superfluous_columns=True,
+    )
     assert result.columns == ["column_1"]
 
 


### PR DESCRIPTION
 - makes `validate()`, `pt.DataFrame.validate()` & `pt.Model.validate()` return the dataframe being validated
 - adds `filter_columns: bool` option to all the `validate()`s
 - adds `iter_models()` to pt.DataFrame which returns an iterator of patito model instances
 - adds `to_list()` to pt.DataFrame which returns a list of patito model instances
 - adds `iter()` to pt.Model which returns an iterator of patito model instances
 - adds `to_list()` to pt.Model which returns a list of patito model instances
 
 Questions
  - happy to remove the `ListableIterator`
  - should I add an example to the readme?
  - how to update docs (by the way I don't think the website docs are up-to-date)