### PR TITLE
Updated _find_errors to use aliased column names from the model schema.

### DIFF
--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -139,7 +139,8 @@ def _find_errors(  # noqa: C901
 
     """
     errors: list[ErrorWrapper] = []
-    schema_subset = columns or schema.columns
+    aliased_schema_columns = [col.alias if col.alias else col_name for col_name, col in schema.model_fields.items()]
+    schema_subset = columns or aliased_schema_columns
     column_subset = columns or dataframe.columns
     if not allow_missing_columns:
         # Check if any columns are missing
@@ -153,7 +154,7 @@ def _find_errors(  # noqa: C901
 
     if not allow_superfluous_columns:
         # Check if any additional columns are included
-        for superfluous_column in set(column_subset) - set(schema.columns):
+        for superfluous_column in set(column_subset) - set(aliased_schema_columns):
             errors.append(
                 ErrorWrapper(
                     SuperfluousColumnsError("Superfluous column"),

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -139,7 +139,10 @@ def _find_errors(  # noqa: C901
 
     """
     errors: list[ErrorWrapper] = []
-    aliased_schema_columns = [col.alias if col.alias else col_name for col_name, col in schema.model_fields.items()]
+    aliased_schema_columns = [
+        col.alias if col.alias else col_name
+        for col_name, col in schema.model_fields.items()
+    ]
     schema_subset = columns or aliased_schema_columns
     column_subset = columns or dataframe.columns
     if not allow_missing_columns:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -872,6 +872,16 @@ def test_validation_column_subset() -> None:
     with pytest.raises(DataFrameValidationError):
         Test.validate(pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}), columns=["c"])
 
+def test_validation_column_alias() -> None:
+    """Ensure that columns are validated using the alias name."""
+
+    class Test(pt.Model):
+        My_Val_A: int = pt.Field(alias="my_val_a")
+
+    Test.validate(pl.DataFrame({"my_val_a": [0]}))  # should pass
+    with pytest.raises(DataFrameValidationError):
+        Test.validate(pl.DataFrame({"my_incorrect_val_a": [0]}))
+
 
 def test_alias_generator() -> None:
     """Allow column name transformations through AliasGenerator."""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -872,6 +872,7 @@ def test_validation_column_subset() -> None:
     with pytest.raises(DataFrameValidationError):
         Test.validate(pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}), columns=["c"])
 
+
 def test_validation_column_alias() -> None:
     """Ensure that columns are validated using the alias name."""
 


### PR DESCRIPTION
This PR addresses issue #75 
It updates the `_find_errors` function to perform column validation using the column alias for any column that has an alias set.