### PR TITLE
feat: Allow clients to pass json_schema_extra too

### DIFF
--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -1330,8 +1330,11 @@ def Field(
                     f"unexpected kwarg {kwarg}={kwargs[kwarg]}.  Add modern_kwargs_only=False to ignore"
                 )
     ci_json = ci.model_dump_json()
+    existing_json_schema_extra = kwargs.pop("json_schema_extra", {})
+    merged_json_schema_extra = {**existing_json_schema_extra, "column_info": ci_json}
+
     return fields.Field(
         *args,
-        json_schema_extra={"column_info": ci_json},
+        json_schema_extra=merged_json_schema_extra,
         **kwargs,
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -594,8 +594,12 @@ def test_json_schema_extra_is_extended_when_it_exists() -> None:
 
     class Model(pt.Model):
         a: int
-        b: int = pt.Field(json_schema_extra={"client_column_metadata": {"group1": "x", "group2": "y"}})
-        c: int = pt.Field(json_schema_extra={"client_column_metadata": {"group1": "xxx"}})
+        b: int = pt.Field(
+            json_schema_extra={"client_column_metadata": {"group1": "x", "group2": "y"}}
+        )
+        c: int = pt.Field(
+            json_schema_extra={"client_column_metadata": {"group1": "xxx"}}
+        )
 
     schema = Model.model_json_schema()  # no serialization issues
     props = schema[

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -587,3 +587,24 @@ def test_model_iter_models_to_list():  # noqa: D103
     assert len(full_list) == len(df)
     for model_instance in full_list:
         assert isinstance(model_instance, SingleColumnModel)
+
+
+def test_json_schema_extra_is_extended_when_it_exists() -> None:
+    """Ensure that the json_schema_extra property is extended with column_info when it is set from the model field."""
+
+    class Model(pt.Model):
+        a: int
+        b: int = pt.Field(json_schema_extra={"client_column_metadata": {"group1": "x", "group2": "y"}})
+        c: int = pt.Field(json_schema_extra={"client_column_metadata": {"group1": "xxx"}})
+
+    schema = Model.model_json_schema()  # no serialization issues
+    props = schema[
+        "properties"
+    ]  # extra fields are stored in modified schema_properties
+    for col in ["b", "c"]:
+        assert "column_info" in props[col]
+        assert "client_column_metadata" in props[col]
+    assert "client_column_metadata" not in props["a"]
+    assert props["b"]["client_column_metadata"]["group1"] == "x"
+    assert props["b"]["client_column_metadata"]["group2"] == "y"
+    assert props["c"]["client_column_metadata"]["group1"] == "xxx"


### PR DESCRIPTION
Currently, if a client passes `json_schema_extra` they would get the following error:
```
TypeError: pydantic.fields.Field() got multiple values for keyword argument 'json_schema_extra'
```

Instead, we should merge the two `json_schema_extra` dicts if one is passed form the client