### PR TITLE
Fix test failure due to polars 1.2

### DIFF
--- a/src/patito/_pydantic/dtypes/utils.py
+++ b/src/patito/_pydantic/dtypes/utils.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Type,
     Union,
     cast,
     get_args,
@@ -87,6 +88,29 @@ def is_optional(type_annotation: type[Any] | Any | None) -> bool:
     """
     return (get_origin(type_annotation) in UNION_TYPES) and (
         type(None) in get_args(type_annotation)
+    )
+
+
+def unwrap_optional(type_annotation: Type[Any] | Any) -> Type:
+    """Return the inner, wrapped type of an Optional.
+
+    Is a no-op for non-Optional types.
+
+    Args:
+        type_annotation: The type annotation to be dewrapped.
+
+    Returns:
+        The input type, but with the outermost Optional removed.
+
+    """
+    return (
+        next(  # pragma: no cover
+            valid_type
+            for valid_type in get_args(type_annotation)
+            if valid_type is not type(None)  # noqa: E721
+        )
+        if is_optional(type_annotation)
+        else type_annotation
     )
 
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -54,7 +54,7 @@ from patito.polars import DataFrame, LazyFrame
 from patito.validators import validate
 
 try:
-    import pandas as pd
+    import pandas as pd  # type: ignore
 
     _PANDAS_AVAILABLE = True
 except ImportError:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -13,7 +13,8 @@ import polars as pl
 import pytest
 from patito import DataFrameValidationError
 from patito._pydantic.dtypes import is_optional
-from patito.validators import _dewrap_optional, validate
+from patito._pydantic.dtypes.utils import unwrap_optional
+from patito.validators import validate
 from pydantic.aliases import AliasGenerator
 from pydantic.config import ConfigDict
 
@@ -36,9 +37,9 @@ def test_is_optional_with_pipe_operator() -> None:
 
 def test_dewrap_optional() -> None:
     """It should return the inner type of Optional types."""
-    assert _dewrap_optional(Optional[int]) is int
-    assert _dewrap_optional(Union[int, None]) is int
-    assert _dewrap_optional(int) is int
+    assert unwrap_optional(Optional[int]) is int
+    assert unwrap_optional(Union[int, None]) is int
+    assert unwrap_optional(int) is int
 
 
 @pytest.mark.skipif(
@@ -48,7 +49,7 @@ def test_dewrap_optional() -> None:
 def test_dewrap_optional_with_pipe_operator() -> None:
     """It should return the inner type of Optional types."""
     assert (  # typing: ignore  # pragma: noqa  # pyright: ignore
-        _dewrap_optional(int | None) is int
+        unwrap_optional(int | None) is int
     )
 
 


### PR DESCRIPTION
 Fixes a bug and supports new polars behaviour

We were currently dropping rows in struct columns that contained only
nulls, potentially dropping values from other columns before validation.
Now we use the entire dataframe again when checking each column. We
might be able to avoid passing the entire dataframe and just passing
series.

Polars 1.2 allows null structs despite filtering them away:
`pl.DataFrame({"foo":{"a":None}}).filter(pl.col("foo").is_not_null())`
still returns rows. We fix this by checking to see if all struct fields
are null, and in that case dropping the row.