### PR TITLE
Simplify and fix ColumnInfo

### DIFF
--- a/src/patito/_pydantic/column_info.py
+++ b/src/patito/_pydantic/column_info.py
@@ -1,21 +1,83 @@
 from __future__ import annotations
 
+import io
 import json
-from typing import (
-    Any,
-    Dict,
-    Optional,
-    Sequence,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Annotated, Optional, Type, TypeVar
 
 import polars as pl
+from polars.datatypes import *  # noqa: F403 # type: ignore
 from polars.datatypes import DataType, DataTypeClass
-from pydantic import BaseModel, field_serializer
+from polars.exceptions import ComputeError
+from pydantic import BaseModel, BeforeValidator, field_serializer
 
-from patito._pydantic.dtypes import parse_composite_dtype
+
+def dtype_deserializer(dtype: str | DataTypeClass | DataType | None):
+    """Deserialize a dtype from json."""
+    if isinstance(dtype, DataTypeClass) or isinstance(dtype, DataType):
+        return dtype
+    else:
+        if dtype == "null" or dtype is None:
+            return None
+        else:
+            return eval(dtype)
+
+
+def expr_deserializer(
+    expr: str | pl.Expr | list[pl.Expr] | None,
+) -> pl.Expr | list[pl.Expr] | None:
+    """Deserialize a polars expression or list thereof from json.
+
+    This is applied both during deserialization and validation.
+    """
+    if expr is None:
+        return None
+    elif isinstance(expr, pl.Expr):
+        return expr
+    elif isinstance(expr, list):
+        return expr
+    elif isinstance(expr, str):
+        if expr == "null":
+            return None
+        # can be either a list of expr or expr
+        elif expr[0] == "[":
+            return [
+                pl.Expr.deserialize(io.StringIO(e), format="json")
+                for e in json.loads(expr)
+            ]
+        else:
+            return pl.Expr.deserialize(io.StringIO(expr), format="json")
+    else:
+        raise ValueError(f"{expr} can not be deserialized.")
+
+
+def expr_or_col_name_deserializer(expr: str | pl.Expr | None) -> pl.Expr | str | None:
+    """Deserialize a polars expression or column name from json.
+
+    This is applied both during deserialization and validation.
+    """
+    if expr is None:
+        return None
+    elif isinstance(expr, pl.Expr):
+        return expr
+    elif isinstance(expr, list):
+        return expr
+    elif isinstance(expr, str):
+        # Default behaviour
+        if expr == "null":
+            return None
+        else:
+            try:
+                return pl.Expr.deserialize(io.StringIO(expr), format="json")
+            except ComputeError:
+                try:
+                    # Column name is being deserialized
+                    return json.loads(expr)
+                except json.JSONDecodeError:
+                    # Column name has been passed literally
+                    # to ColumnInfo(derived_from="foo")
+                    return expr
+    else:
+        raise ValueError(f"{expr} can not be deserialized.")
 
 
 class ColumnInfo(BaseModel, arbitrary_types_allowed=True):
@@ -34,9 +96,15 @@ class ColumnInfo(BaseModel, arbitrary_types_allowed=True):
 
     """
 
-    dtype: Optional[Union[DataTypeClass, DataType]] = None
-    constraints: Optional[Union[pl.Expr, Sequence[pl.Expr]]] = None
-    derived_from: Optional[Union[str, pl.Expr]] = None
+    dtype: Annotated[
+        DataType | DataTypeClass | None, BeforeValidator(dtype_deserializer)
+    ] = None
+    constraints: Annotated[
+        pl.Expr | list[pl.Expr] | None, BeforeValidator(expr_deserializer)
+    ] = None
+    derived_from: Annotated[
+        str | pl.Expr | None, BeforeValidator(expr_or_col_name_deserializer)
+    ] = None
     unique: Optional[bool] = None
 
     def __repr__(self) -> str:
@@ -56,39 +124,24 @@ class ColumnInfo(BaseModel, arbitrary_types_allowed=True):
         return f"ColumnInfo({string})"
 
     @field_serializer("constraints", "derived_from")
-    def serialize_exprs(self, exprs: str | pl.Expr | Sequence[pl.Expr] | None) -> Any:
-        if exprs is None:
-            return None
-        elif isinstance(exprs, str):
-            return exprs
-        elif isinstance(exprs, pl.Expr):
-            return self._serialize_expr(exprs)
-        elif isinstance(exprs, Sequence):
-            return [self._serialize_expr(c) for c in exprs]
+    def expr_serializer(self, expr: None | pl.Expr | list[pl.Expr]):
+        """Converts polars expr to json."""
+        if expr is None:
+            return "null"
+        elif isinstance(expr, str):
+            return json.dumps(expr)
+        elif isinstance(expr, list):
+            return json.dumps([e.meta.serialize(format="json") for e in expr])
         else:
-            raise ValueError(f"Invalid type for exprs: {type(exprs)}")
-
-    def _serialize_expr(self, expr: pl.Expr) -> Dict:
-        if isinstance(expr, pl.Expr):
-            return json.loads(
-                expr.meta.serialize(format="json")
-            )  # can we access the dictionary directly?
-        else:
-            raise ValueError(f"Invalid type for expr: {type(expr)}")
+            return expr.meta.serialize(format="json")
 
     @field_serializer("dtype")
-    def serialize_dtype(self, dtype: DataTypeClass | DataType | None) -> Any:
-        """Serialize a polars dtype.
-
-        References:
-            [1] https://stackoverflow.com/questions/76572310/how-to-serialize-deserialize-polars-datatypes
-        """
+    def dtype_serializer(self, dtype: DataTypeClass | DataType | None) -> str:
+        """Converts polars dtype to json."""
         if dtype is None:
-            return None
-        elif isinstance(dtype, DataTypeClass) or isinstance(dtype, DataType):
-            return parse_composite_dtype(dtype)
+            return "null"
         else:
-            raise ValueError(f"Invalid type for dtype: {type(dtype)}")
+            return str(dtype)
 
 
 CI = TypeVar("CI", bound=Type[ColumnInfo])

--- a/src/patito/_pydantic/column_info.py
+++ b/src/patito/_pydantic/column_info.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import io
 import json
-from typing import Annotated, Optional, Type, TypeVar
+from collections.abc import Sequence
+from typing import Annotated, Optional, Type, TypeVar, Union
 
 import polars as pl
 from polars.datatypes import *  # noqa: F403 # type: ignore
@@ -97,13 +98,13 @@ class ColumnInfo(BaseModel, arbitrary_types_allowed=True):
     """
 
     dtype: Annotated[
-        DataType | DataTypeClass | None, BeforeValidator(dtype_deserializer)
+        Optional[Union[DataTypeClass, DataType]], BeforeValidator(dtype_deserializer)
     ] = None
     constraints: Annotated[
-        pl.Expr | list[pl.Expr] | None, BeforeValidator(expr_deserializer)
+        Optional[Union[pl.Expr, Sequence[pl.Expr]]], BeforeValidator(expr_deserializer)
     ] = None
     derived_from: Annotated[
-        str | pl.Expr | None, BeforeValidator(expr_or_col_name_deserializer)
+        Optional[Union[str, pl.Expr]], BeforeValidator(expr_or_col_name_deserializer)
     ] = None
     unique: Optional[bool] = None
 

--- a/src/patito/_pydantic/column_info.py
+++ b/src/patito/_pydantic/column_info.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import json
 from collections.abc import Sequence
-from typing import Annotated, Optional, Type, TypeVar, Union
+from typing import Annotated, Optional, Union
 
 import polars as pl
 from polars.datatypes import *  # noqa: F403 # type: ignore
@@ -143,6 +143,3 @@ class ColumnInfo(BaseModel, arbitrary_types_allowed=True):
             return "null"
         else:
             return str(dtype)
-
-
-CI = TypeVar("CI", bound=Type[ColumnInfo])

--- a/src/patito/_pydantic/dtypes/dtypes.py
+++ b/src/patito/_pydantic/dtypes/dtypes.py
@@ -9,13 +9,13 @@ from polars.datatypes import DataType, DataTypeClass
 from polars.datatypes.group import DataTypeGroup
 from pydantic import TypeAdapter
 
+from patito._pydantic.column_info import ColumnInfo
 from patito._pydantic.dtypes.utils import (
     PT_BASE_SUPPORTED_DTYPES,
     PydanticBaseType,
     _pyd_type_to_default_dtype,
     _pyd_type_to_valid_dtypes,
     _without_optional,
-    dtype_from_string,
 )
 from patito._pydantic.repr import display_as_type
 
@@ -208,9 +208,9 @@ class DtypeResolver:
         props: Dict,
     ) -> DataType | None:
         if "column_info" in props:  # user has specified in patito model
-            if props["column_info"]["dtype"] is not None:
-                dtype = dtype_from_string(props["column_info"]["dtype"])
-                dtype = dtype() if isinstance(dtype, DataTypeClass) else dtype
+            ci = ColumnInfo.model_validate_json(props["column_info"])
+            if ci.dtype is not None:
+                dtype = ci.dtype() if isinstance(ci.dtype, DataTypeClass) else ci.dtype
                 return dtype
         if "type" not in props:
             if "enum" in props:

--- a/src/patito/_pydantic/dtypes/utils.py
+++ b/src/patito/_pydantic/dtypes/utils.py
@@ -10,7 +10,6 @@ from typing import (
     Sequence,
     Type,
     Union,
-    cast,
     get_args,
     get_origin,
 )
@@ -23,9 +22,6 @@ from polars.datatypes.group import (
     FLOAT_DTYPES,
     INTEGER_DTYPES,
     DataTypeGroup,
-)
-from polars.polars import (
-    dtype_str_repr,  # TODO: this is a rust function, can we implement our own string parser for Time/Duration/Datetime?
 )
 
 PYTHON_TO_PYDANTIC_TYPES = {
@@ -116,20 +112,7 @@ def unwrap_optional(type_annotation: Type[Any] | Any) -> Type:
 
 def parse_composite_dtype(dtype: DataTypeClass | DataType) -> str:
     """For serialization, converts polars dtype to string representation."""
-    if dtype.is_nested():
-        if dtype == pl.Struct or isinstance(dtype, pl.Struct):
-            raise NotImplementedError("Structs not yet supported by patito")
-        if not isinstance(dtype, pl.List) or isinstance(dtype, pl.Array):
-            raise NotImplementedError(
-                f"Unsupported nested dtype: {dtype} of type {type(dtype)}"
-            )
-        if dtype.inner is None:
-            return convert.DataTypeMappings.DTYPE_TO_FFINAME[dtype.base_type()]
-        return f"{convert.DataTypeMappings.DTYPE_TO_FFINAME[dtype.base_type()]}[{parse_composite_dtype(dtype.inner)}]"
-    elif dtype.is_temporal():
-        return cast(str, dtype_str_repr(dtype))
-    else:
-        return convert.DataTypeMappings.DTYPE_TO_FFINAME[dtype]
+    return str(dtype)
 
 
 def dtype_from_string(v: str) -> Optional[Union[DataTypeClass, DataType]]:

--- a/src/patito/_pydantic/schema.py
+++ b/src/patito/_pydantic/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Type, cast, get_args
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Type, get_args
 
 from pydantic.fields import FieldInfo
 
@@ -56,7 +56,7 @@ def column_infos_for_model(cls: Type[ModelType]) -> Mapping[str, ColumnInfo]:
             raise NotImplementedError(
                 "Callable json_schema_extra not supported by patito."
             )
-        return cast(ColumnInfo, field.json_schema_extra["column_info"])
+        return ColumnInfo.model_validate_json(field.json_schema_extra["column_info"])
 
     return {k: get_column_info(v) for k, v in fields.items()}
 

--- a/src/patito/_pydantic/schema.py
+++ b/src/patito/_pydantic/schema.py
@@ -51,7 +51,7 @@ def column_infos_for_model(cls: Type[ModelType]) -> Mapping[str, ColumnInfo]:
 
     def get_column_info(field: FieldInfo) -> ColumnInfo:
         if field.json_schema_extra is None:
-            return cast(ColumnInfo, cls.column_info_class())
+            return ColumnInfo()
         elif callable(field.json_schema_extra):
             raise NotImplementedError(
                 "Callable json_schema_extra not supported by patito."

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -73,8 +73,6 @@ class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
     Responsible for setting any relevant model-dependent class properties.
     """
 
-    column_info_class: ClassVar[Type[ColumnInfo]] = ColumnInfo
-
     if TYPE_CHECKING:
         model_fields: ClassVar[Dict[str, fields.FieldInfo]]
 
@@ -549,7 +547,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             properties = cls._schema_properties()[field]
             info = cls.column_infos[field]
         else:
-            info = cls.column_info_class()
+            info = ColumnInfo()
         properties = properties or {}
 
         if "type" in properties:

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -32,7 +32,6 @@ from polars.datatypes import DataType, DataTypeClass
 from pydantic import (  # noqa: F401
     BaseModel,
     create_model,
-    field_serializer,
     fields,
 )
 from pydantic._internal._model_construction import (

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -12,7 +12,6 @@ from typing import (
     ClassVar,
     Dict,
     FrozenSet,
-    Generic,
     List,
     Literal,
     Mapping,
@@ -38,7 +37,7 @@ from pydantic._internal._model_construction import (
 )
 from zoneinfo import ZoneInfo
 
-from patito._pydantic.column_info import CI, ColumnInfo
+from patito._pydantic.column_info import ColumnInfo
 from patito._pydantic.dtypes import (
     default_dtypes_for_model,
     is_optional,
@@ -65,7 +64,7 @@ if TYPE_CHECKING:
 ModelType = TypeVar("ModelType", bound="Model")
 
 
-class ModelMetaclass(PydanticModelMetaclass, Generic[CI]):
+class ModelMetaclass(PydanticModelMetaclass):
     """Metaclass used by patito.Model.
 
     Responsible for setting any relevant model-dependent class properties.

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import itertools
 from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
-from functools import partial
 from inspect import getfullargspec
 from typing import (
     TYPE_CHECKING,
@@ -42,7 +41,6 @@ from zoneinfo import ZoneInfo
 from patito._pydantic.column_info import CI, ColumnInfo
 from patito._pydantic.dtypes import (
     default_dtypes_for_model,
-    dtype_from_string,
     is_optional,
     valid_dtypes_for_model,
     validate_annotation,
@@ -629,10 +627,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 return date(year=1970, month=1, day=1)
             elif "format" in properties and properties["format"] == "date-time":
                 if "column_info" in properties:
-                    dtype_str = properties["column_info"]["dtype"]
-                    dtype = dtype_from_string(dtype_str)
+                    ci = ColumnInfo.model_validate_json(properties["column_info"])
+                    dtype = ci.dtype
                     if getattr(dtype, "time_zone", None) is not None:
-                        tzinfo = ZoneInfo(dtype.time_zone)
+                        tzinfo = ZoneInfo(dtype.time_zone)  # type: ignore
                     else:
                         tzinfo = None
                     return datetime(year=1970, month=1, day=1, tzinfo=tzinfo)
@@ -1259,8 +1257,8 @@ FIELD_KWARGS = getfullargspec(fields.Field)
 # Helper function for patito Field.
 
 
-def FieldCI(
-    column_info: Type[ColumnInfo], *args: Any, **kwargs: Any
+def Field(
+    *args: Any, **kwargs: Any
 ) -> Any:  # annotate with Any to make the downstream type annotations happy
     """Annotate model field with additional type and validation information.
 
@@ -1331,7 +1329,7 @@ def FieldCI(
             Polars dtype Int64 does not match model field type. (type=type_error.columndtype)
 
     """
-    ci = column_info(**kwargs)
+    ci = ColumnInfo(**kwargs)
     for field in ci.model_fields_set:
         kwargs.pop(field)
     if kwargs.pop("modern_kwargs_only", True):
@@ -1340,11 +1338,9 @@ def FieldCI(
                 raise ValueError(
                     f"unexpected kwarg {kwarg}={kwargs[kwarg]}.  Add modern_kwargs_only=False to ignore"
                 )
+    ci_json = ci.model_dump_json()
     return fields.Field(
         *args,
-        json_schema_extra={"column_info": ci},
+        json_schema_extra={"column_info": ci_json},
         **kwargs,
     )
-
-
-Field = partial(FieldCI, column_info=ColumnInfo)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,6 +11,7 @@ from typing import Optional, Type
 import patito as pt
 import polars as pl
 import pytest
+from patito._pydantic.column_info import ColumnInfo
 from patito._pydantic.dtypes.utils import (
     DATE_DTYPES,
     TIME_DTYPES,
@@ -507,10 +508,17 @@ def test_column_infos() -> None:
     ]  # extra fields are stored in modified schema_properties
     for col in ["b", "c", "d", "e"]:
         assert "column_info" in props[col]
-    assert props["b"]["column_info"]["constraints"] is not None
-    assert props["c"]["column_info"]["derived_from"] is not None
-    assert props["d"]["column_info"]["dtype"] is not None
-    assert props["e"]["column_info"]["unique"] is not None
+
+    assert (
+        ColumnInfo.model_validate_json(props["b"]["column_info"]).constraints
+        is not None
+    )
+    assert (
+        ColumnInfo.model_validate_json(props["c"]["column_info"]).derived_from
+        is not None
+    )
+    assert ColumnInfo.model_validate_json(props["d"]["column_info"]).dtype is not None
+    assert ColumnInfo.model_validate_json(props["e"]["column_info"]).unique is not None
     infos = Model.column_infos
     assert infos["b"].constraints is not None
     assert infos["c"].derived_from is not None


### PR DESCRIPTION
This PR simplifies how we use ColumnInfo within patito. I also fix it to work as I envisaged, which is to be able to fully serialize and deserialize polars expressions and dtypes so that we can export patito models as a json schema.