### PR TITLE
Specify all supported python versions for redundancy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       with:
         python-version: |
           3.9
+          3.10
+          3.11
           3.12
         architecture: x64
     - run: pip install nox==2023.4.22


### PR DESCRIPTION
This passes[ locally with `act`](https://github.com/nektos/act). Hope it passes online too...