### PR TITLE
int model annotation should return only integer dtypes as valid

### DIFF
--- a/src/patito/_pydantic/dtypes/dtypes.py
+++ b/src/patito/_pydantic/dtypes/dtypes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from functools import cache, reduce
-from operator import and_, or_
+from operator import or_
 from typing import TYPE_CHECKING, Any
 
 import polars as pl

--- a/src/patito/_pydantic/dtypes/dtypes.py
+++ b/src/patito/_pydantic/dtypes/dtypes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from functools import cache, reduce
-from operator import and_
+from operator import and_, or_
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -144,7 +144,7 @@ class DtypeResolver:
             valid_type_sets.append(
                 self._pydantic_subschema_to_valid_polars_types(schema)
             )
-        return reduce(and_, valid_type_sets) if valid_type_sets else DataTypeGroup([])
+        return reduce(or_, valid_type_sets) if valid_type_sets else DataTypeGroup([])
 
     def _pydantic_subschema_to_valid_polars_types(
         self,

--- a/src/patito/_pydantic/dtypes/utils.py
+++ b/src/patito/_pydantic/dtypes/utils.py
@@ -124,7 +124,7 @@ def _pyd_type_to_valid_dtypes(
         _validate_enum_values(pyd_type, enum)
         return DataTypeGroup([pl.Enum(enum), pl.String], match_base_type=False)
     if pyd_type.value == "integer":
-        return DataTypeGroup(INTEGER_DTYPES | FLOAT_DTYPES)
+        return DataTypeGroup(INTEGER_DTYPES)
     elif pyd_type.value == "number":
         return (
             FLOAT_DTYPES

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -51,9 +51,7 @@ def test_valids_basic_annotations() -> None:
     with pytest.raises(TypeError, match="Mixed type enums not supported"):
         DtypeResolver(Literal[1, 2, "3"]).valid_polars_dtypes()  # pyright: ignore
 
-    assert DtypeResolver(
-        Literal["a", "b", "c"]
-    ).valid_polars_dtypes() == {  # pyright: ignore
+    assert DtypeResolver(Literal["a", "b", "c"]).valid_polars_dtypes() == {  # pyright: ignore
         pl.Enum(["a", "b", "c"]),
         pl.String,
     }

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -210,7 +210,7 @@ def test_mapping_to_polars_dtypes() -> None:
 
     assert CompleteModel.valid_dtypes == {
         "str_column": {pl.String},
-        "int_column": DataTypeGroup(INTEGER_DTYPES | FLOAT_DTYPES),
+        "int_column": DataTypeGroup(INTEGER_DTYPES),
         "float_column": FLOAT_DTYPES,
         "bool_column": {pl.Boolean},
         "date_column": DATE_DTYPES,
@@ -235,11 +235,11 @@ def test_mapping_to_polars_dtypes() -> None:
             ]
         ),
         "list_int_column": DataTypeGroup(
-            [pl.List(x) for x in DataTypeGroup(INTEGER_DTYPES | FLOAT_DTYPES)]
+            [pl.List(x) for x in DataTypeGroup(INTEGER_DTYPES)]
         ),
         "list_str_column": DataTypeGroup([pl.List(pl.String)]),
         "list_opt_column": DataTypeGroup(
-            [pl.List(x) for x in DataTypeGroup(INTEGER_DTYPES | FLOAT_DTYPES)]
+            [pl.List(x) for x in DataTypeGroup(INTEGER_DTYPES)]
         ),
     }
 


### PR DESCRIPTION
I found that when I had a model with a column annotated as `int` then a DataFrame with a column of any `float` dtype would pass validation!

Example:

```python
import patito as pt

class TestModel(pt.Model):
    a: int

result = TestModel.DataFrame({'a': [1.0, 2.0]}).validate()

print(result)

# shape: (2, 1)
# ┌─────┐
# │ a   │
# │ --- │
# │ f64 │
# ╞═════╡
# │ 1.0 │
# │ 2.0 │
# └─────┘
```

To fix this I updated the `DtypeResolver` to return only integer dtypes as valid when a column is annotated with `int`, instead of the union of integer and float dtypes.

When updating the tests I noticed that Patito is using the wrong operator when working out the valid dtypes for `Union` annotations. It should be `operator.or_` instead of `operator.and_` (which is intersection).

Although we know that polars columns can't have two dtypes for a single column, so should `union` annotations even be supported? Problem for someone's later work...