### PR TITLE
Fix: empty List[Struct] should not try to use nested schema since there are no struct to validate

### DIFF
--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -301,6 +301,7 @@ def _find_errors(  # noqa: C901
 
             dataframe_tmp = (
                 dataframe_tmp.select(column_name)
+                .filter(pl.col(column_name).list.len() > 0)
                 .explode(column_name)
                 .unnest(column_name)
             )

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -9,6 +9,13 @@ from pydantic import AwareDatetime
 import patito as pt
 
 
+class VerySmallModel(pt.Model):
+    """Very small model for testing."""
+
+    a: int
+    b: str
+
+
 class SmallModel(pt.Model):
     """Small model for testing."""
 
@@ -37,6 +44,7 @@ class ManyTypes(pt.Model):
     date_value: date
     datetime_value: datetime
     pt_model_value: SmallModel
+    pt_list_model_value: list[VerySmallModel]
 
 
 class CompleteModel(pt.Model):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,7 +26,7 @@ from patito._pydantic.dtypes.utils import (
     DATE_DTYPES,
     TIME_DTYPES,
 )
-from tests.examples import CompleteModel, ManyTypes, SmallModel
+from tests.examples import CompleteModel, ManyTypes, SmallModel, VerySmallModel
 
 
 def test_model_example() -> None:
@@ -47,11 +47,13 @@ def test_model_example() -> None:
         "date_value": date(year=1970, month=1, day=1),
         "datetime_value": datetime(year=1970, month=1, day=1),
         "pt_model_value": SmallModel.example().model_dump(),
+        "pt_list_model_value": [VerySmallModel.example().model_dump()],
     }
     assert ManyTypes.example(
         bool_value=True,
         default_value="override",
         optional_value=1,
+        pt_list_model_value=[],
     ).model_dump() == {
         "int_value": -1,
         "float_value": -0.5,
@@ -64,9 +66,15 @@ def test_model_example() -> None:
         "date_value": date(year=1970, month=1, day=1),
         "datetime_value": datetime(year=1970, month=1, day=1),
         "pt_model_value": SmallModel.example().model_dump(),
+        "pt_list_model_value": [],
     }
 
     ManyTypes.validate(ManyTypes.examples({"int_value": range(200)}))
+
+    # Empty list should be valid
+    ManyTypes.validate(
+        ManyTypes.examples({"pt_list_model_value": [[], [VerySmallModel.example()]]})
+    )
 
     # For now, valid regex data is not implemented
     class RegexModel(pt.Model):
@@ -559,7 +567,7 @@ def test_validation_alias():
 
 
 def test_validation_returns_df():  # noqa: D103
-    for Model in [SmallModel, ManyTypes, CompleteModel]:
+    for Model in [VerySmallModel, SmallModel, ManyTypes, CompleteModel]:
         df = Model.examples()
         remade_model = Model.validate(df)
         assert_frame_equal(remade_model, df)


### PR DESCRIPTION
This PR fixes an unexpected behaviour:

When defining a column as a `List[SomeModel]`, the validator creates a temporary dataframe with the selected column exploded into its nested struct properties. But it does so for empty lists hence creating columns with `null` values, which is incorrect since there are no actual struct instance in such lists

Here, we filter out the rows where the list is empty to avoid that

NB: The only workaround atm is to mark each struct field as optional, which is incorrect: when there is an item in the list, its fields shall not be null.

## Before the fix
<img width="674" alt="Screenshot 2024-12-26 at 18 29 40" src="https://github.com/user-attachments/assets/18acd8d4-ed80-4a8a-a88d-04aeb83b19de" />

## After the fix
<img width="1688" alt="Screenshot 2024-12-26 at 18 29 31" src="https://github.com/user-attachments/assets/032ca0c6-a4ec-4211-b982-2ca1ee100375" />


