### PR TITLE
fix: Respect columns order in `Model.examples`

### DIFF
--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -863,7 +863,7 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             if column_name not in kwargs:
                 if column_name in cls.unique_columns:
                     unique_series.append(
-                        pl.first().cum_count().cast(dtype).alias(column_name)
+                        pl.int_range(pl.len()).cast(dtype).alias(column_name)
                     )
                 else:
                     example_value = cls.example_value(field=column_name)
@@ -881,7 +881,12 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             else:
                 series.append(pl.lit(value, dtype=dtype).alias(column_name))
 
-        return cls.DataFrame().with_columns(series).with_columns(unique_series)
+        return (
+            cls.DataFrame()
+            .with_columns(series)
+            .with_columns(unique_series)
+            .select(cls.columns)  # reorder columns
+        )
 
     @classmethod
     def join(

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -626,3 +626,15 @@ def test_iter_models_to_list() -> None:
     assert models[1].a == 2
     for model in models:
         assert isinstance(model, Model)
+
+
+def test_exmaple_column_order_18() -> None:
+    """Ensure correct order with iterable."""
+
+    class Test(pt.Model):
+        a: str
+        b: str
+
+    assert Test.examples({"a": ["1"], "b": ["2"]}).columns == ["a", "b"]
+    assert Test.examples({"a": ["1"]}).columns == ["a", "b"]
+    assert Test.examples({"b": ["2"]}).columns == ["a", "b"]


### PR DESCRIPTION
fixes: https://github.com/JakobGM/patito/issues/18