### PR TITLE
RFC: use ConfigDict allow extra instead of allow_superfluous_columns

### DIFF
--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -129,7 +129,7 @@ def _find_errors(  # noqa: C901
                 )
             )
 
-    if not allow_superfluous_columns:
+    if not (allow_superfluous_columns or schema.model_config.get("extra") == "allow"):
         # Check if any additional columns are included
         for superfluous_column in set(column_subset) - set(schema.columns):
             errors.append(


### PR DESCRIPTION
linked to: https://github.com/JakobGM/patito/issues/37

I think we should depreciate `allow_missing_columns` and `allow_superfluous_columns` and use the pydantic way to put this.