### PR TITLE
Bugfix for handling new polars concat behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Take the following function as an example:
 ```py
 import polars as pl
 
+
 def num_products_for_sale(products: pl.DataFrame) -> int:
     Product.validate(products)
     return products.filter(pl.col("is_for_sale")).height
@@ -185,7 +186,8 @@ class Product(pt.Model):
     status: Literal["draft", "for-sale", "discontinued"] = "for-sale"
     # The eurocent cost is extracted from the Euro cost string "€X.Y EUR"
     eurocent_cost: int = pt.Field(
-        derived_from=100 * pl.col("cost").str.extract(r"€(\d+\.+\d+)").cast(float).round(2)
+        derived_from=100
+        * pl.col("cost").str.extract(r"€(\d+\.+\d+)").cast(float).round(2)
     )
 
 
@@ -231,6 +233,7 @@ Patito allows you to embed row-level logic in methods defined on the model.
 # models.py
 import patito as pt
 
+
 class Product(pt.Model):
     product_id: int = pt.Field(unique=True)
     name: str
@@ -262,7 +265,6 @@ print(milk.url)
 If you "connect" the `Product` model with the `DataFrame` by the use of `patito.DataFrame.set_model()`, or alternatively by using `Product.DataFrame` directly, you can use the `.get()` method in order to filter the data frame down to a single row _and_ cast it to the respective model class:
 
 ```py
-
 products = Product.DataFrame(
     {
         "product_id": [1, 2],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "patito"
-version = "0.8.6"
+version = "0.8.7"
 description = "A dataframe modelling library built on top of polars and pydantic."
 authors = [
     { name = "Jakob Gerhard Martinussen", email = "jakobgm@gmail.com" },

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -51,6 +51,7 @@ except ImportError:
 if TYPE_CHECKING:
     import patito.polars
 
+
 # The generic type of a single row in given Relation.
 # Should be a typed subclass of Model.
 ModelType = TypeVar("ModelType", bound="Model")
@@ -859,18 +860,15 @@ class Model(BaseModel, metaclass=ModelMetaclass):
 
         # Recent polar changes throw an error when concating series of different lenghts, determine the size of the dataframe
         max_series_size = None
-        for _, v in kwargs:
+
+        for _, v in kwargs.items():
             if isinstance(v, Iterable) and not isinstance(v, str):
                 series_size = len(v)
             else:
                 series_size = 1
             if max_series_size is None:
                 max_series_size = series_size
-            else:
-                if max_series_size != series_size:
-                    raise ValueError(
-                        "Polars can not handle concating series of differing lengths"
-                    )
+
         if max_series_size is None:
             max_series_size = 1
 
@@ -885,10 +883,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                 else:
                     example_values = [
                         cls.example_value(field=column_name)
-                        for i in range(max_series_size)
+                        for _ in range(max_series_size)
                     ]
                     series.append(
-                        pl.Series(column_name, values=[example_values], dtype=dtype)
+                        pl.Series(column_name, values=example_values, dtype=dtype)
                     )
                 continue
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -857,6 +857,23 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if wrong_columns:
             raise TypeError(f"{cls.__name__} does not contain fields {wrong_columns}!")
 
+        # Recent polar changes throw an error when concating series of different lenghts, determine the size of the dataframe
+        max_series_size = None
+        for _, v in kwargs:
+            if isinstance(v, Iterable) and not isinstance(v, str):
+                series_size = len(v)
+            else:
+                series_size = 1
+            if max_series_size is None:
+                max_series_size = series_size
+            else:
+                if max_series_size != series_size:
+                    raise ValueError(
+                        "Polars can not handle concating series of differing lengths"
+                    )
+        if max_series_size is None:
+            max_series_size = 1
+
         series: list[pl.Series | pl.Expr] = []
         unique_series = []
         for column_name, dtype in cls.dtypes.items():
@@ -866,9 +883,12 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                         pl.first().cum_count().cast(dtype).alias(column_name)
                     )
                 else:
-                    example_value = cls.example_value(field=column_name)
+                    example_values = [
+                        cls.example_value(field=column_name)
+                        for i in range(max_series_size)
+                    ]
                     series.append(
-                        pl.Series(column_name, values=[example_value], dtype=dtype)
+                        pl.Series(column_name, values=[example_values], dtype=dtype)
                     )
                 continue
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -858,20 +858,6 @@ class Model(BaseModel, metaclass=ModelMetaclass):
         if wrong_columns:
             raise TypeError(f"{cls.__name__} does not contain fields {wrong_columns}!")
 
-        # Recent polar changes throw an error when concating series of different lenghts, determine the size of the dataframe
-        max_series_size = None
-
-        for _, v in kwargs.items():
-            if isinstance(v, Iterable) and not isinstance(v, str):
-                series_size = len(v)
-            else:
-                series_size = 1
-            if max_series_size is None:
-                max_series_size = series_size
-
-        if max_series_size is None:
-            max_series_size = 1
-
         series: list[pl.Series | pl.Expr] = []
         unique_series = []
         for column_name, dtype in cls.dtypes.items():
@@ -881,12 +867,10 @@ class Model(BaseModel, metaclass=ModelMetaclass):
                         pl.first().cum_count().cast(dtype).alias(column_name)
                     )
                 else:
-                    example_values = [
-                        cls.example_value(field=column_name)
-                        for _ in range(max_series_size)
-                    ]
                     series.append(
-                        pl.Series(column_name, values=example_values, dtype=dtype)
+                        pl.lit(cls.example_value(field=column_name), dtype=dtype).alias(
+                            column_name
+                        )
                     )
                 continue
 

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -68,9 +68,9 @@ def _transform_df(dataframe: pl.DataFrame, schema: type[Model]) -> pl.DataFrame:
     if alias_gen := schema.model_config.get("alias_generator"):
         if isinstance(alias_gen, AliasGenerator):
             alias_func = alias_gen.validation_alias or alias_gen.alias
-            assert (
-                alias_func is not None
-            ), "An AliasGenerator must contain a transforming function"
+            assert alias_func is not None, (
+                "An AliasGenerator must contain a transforming function"
+            )
         else:  # alias_gen is a function
             alias_func = alias_gen
 


### PR DESCRIPTION
Recent polars changes (>1.43) seemed to change how series would be broadcasted when concating series of different lengths. 

I changed how unspecified columns were constructed for examples from a simple Series to a pl.Lit. This seemed to have fixed the broadcasting issue. Tested in my own code and seemed to solve the error. 